### PR TITLE
Add Castoro font

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A modern web application exploring classical virtues through interactive storyte
 
 - **Framework**: Next.js 14 with App Router
 - **Language**: TypeScript
-- **Styling**: Tailwind CSS
+- **Styling**: Tailwind CSS with Castoro and Inter via `next/font`
 - **UI Components**: shadcn/ui
 - **Content**: MDX for rich content authoring
 - **Analytics**: Vercel Analytics

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,8 +4,6 @@
 
 @layer base {
   :root {
-    --font-heading: 'Times New Roman', 'Times', 'Georgia', 'Playfair Display', 'serif';
-    --font-body: 'Inter', 'Roboto', 'Arial', 'Helvetica', 'sans-serif';
     --destructive-foreground: 60 20% 95%;
     --secondary-foreground: 60 20% 95%;
     --popover-foreground: 60 10% 20%;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
 import { Analytics } from "@vercel/analytics/react"
 import { cn } from '@/lib/utils'
-import { fontHeading, fontBody } from '@/lib/fonts'
 import ErrorBoundary from '@/components/ErrorBoundary'
 import './globals.css'
+import { fontHeading, fontBody } from '@/lib/fonts'
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://classicalvirtues.com'),

--- a/src/lib/fonts.ts
+++ b/src/lib/fonts.ts
@@ -1,10 +1,14 @@
-// System fonts fallback configuration
-export const fontHeading = {
-  variable: '--font-heading',
-  className: 'font-serif'
-}
+import { Castoro, Inter } from 'next/font/google'
 
-export const fontBody = {
-  variable: '--font-body', 
-  className: 'font-sans'
-}
+export const fontHeading = Castoro({
+  variable: '--font-heading',
+  subsets: ['latin'],
+  weight: '400',
+  display: 'swap'
+})
+
+export const fontBody = Inter({
+  variable: '--font-body',
+  subsets: ['latin'],
+  display: 'swap'
+})


### PR DESCRIPTION
## Summary
- use Castoro as the main serif font with next/font
- reorder imports in layout so font CSS loads after global styles
- remove hardcoded font vars in globals.css
- mention Castoro + Inter in README

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687aa93a0fe8832d89853dcb814fc569