### PR TITLE
Adjust card width

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,7 +14,7 @@ export default function Home() {
 
   return (
     <div className="flex flex-col items-center justify-center min-h-screen bg-background p-4">
-      <div className="max-w-4xl w-full space-y-8">
+      <div className="max-w-5xl w-full space-y-8">
         <header className="text-center space-y-4">
           <h1 className="text-4xl font-bold tracking-tighter">Classical Virtues</h1>
           <p className="text-muted-foreground text-lg">


### PR DESCRIPTION
## Summary
- expand the homepage container so cards appear slightly wider

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687ab978859c832d8fddda86bb8ef7d7