### PR TITLE
Improve AudioPlayer on mobile and add Media Session

### DIFF
--- a/src/app/stories/[slug]/page.tsx
+++ b/src/app/stories/[slug]/page.tsx
@@ -169,7 +169,7 @@ export default function Post({ params }: { params: { slug: string } }) {
             <div className="bg-background rounded-lg p-4 w-full h-[100px] animate-pulse" />
           </Card>
         }>
-          <AudioPlayer audioUrl={post.audioUrl} />
+          <AudioPlayer audioUrl={post.audioUrl} title={post.title} image={post.image} />
         </Suspense>
       )}
       <h1 className="text-4xl font-bold mb-4 font-heading">{post.title}</h1>

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -149,7 +149,13 @@ export default function AudioPlayer({ audioUrl, title, image }: AudioPlayerProps
           </div>
         ) : (
           <div className="flex items-center space-x-4">
-            <Button variant="outline" size="icon" onClick={togglePlayPause} aria-label={isPlaying ? "Pause" : "Play"}>
+            <Button
+              variant="outline"
+              size="icon"
+              className="h-10 w-10"
+              onClick={togglePlayPause}
+              aria-label={isPlaying ? "Pause" : "Play"}
+            >
               {isPlaying ? (
                 <PauseIcon className="w-5 h-5 text-muted-foreground" />
               ) : (


### PR DESCRIPTION
## Summary
- tweak AudioPlayer play/pause button variant
- update AudioPlayer to use the Media Session API
- pass story title and image to the player

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687b300ede3c832d80073edb161ab5fd