### PR TITLE
Fix Basehub Vercel build errors

### DIFF
--- a/basehub.config.ts
+++ b/basehub.config.ts
@@ -1,15 +1,20 @@
 import { setGlobalConfig } from 'basehub'
 
-// Configure Basehub globally
-setGlobalConfig({
-  /**
-   * Get your token from: https://basehub.com/[your-org]/[your-repo]/settings/api
-   */
-  token: process.env.BASEHUB_TOKEN,
-  
-  /**
-   * Optional: Enable draft mode for previewing unpublished content
-   */
-  draft: process.env.NODE_ENV === 'development',
-})
+// Configure Basehub globally with better error handling
+if (process.env.BASEHUB_TOKEN) {
+  setGlobalConfig({
+    /**
+     * Get your token from: https://basehub.com/[your-org]/[your-repo]/settings/api
+     */
+    token: process.env.BASEHUB_TOKEN,
+    
+    /**
+     * Optional: Enable draft mode for previewing unpublished content
+     * Only in development, not during Vercel builds
+     */
+    draft: process.env.NODE_ENV === 'development' && !process.env.VERCEL,
+  })
+} else {
+  console.warn('⚠️ BASEHUB_TOKEN not found - Basehub features will be disabled')
+}
   

--- a/src/app/api/debug-basehub/route.ts
+++ b/src/app/api/debug-basehub/route.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from 'next/server'
 import { getAllStories } from '@/lib/basehub'
 
+// Force dynamic for API routes to prevent build-time execution
+export const dynamic = 'force-dynamic'
+
 export async function GET() {
   try {
     const stories = await getAllStories()

--- a/src/app/api/stories/route.ts
+++ b/src/app/api/stories/route.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from 'next/server';
 import { getAllStories } from '@/lib/stories';
 
+// Force dynamic for API routes to prevent build-time execution
+export const dynamic = 'force-dynamic'
+
 export async function GET() {
   try {
     const stories = await getAllStories();

--- a/src/app/revalidate-sitemap/route.ts
+++ b/src/app/revalidate-sitemap/route.ts
@@ -2,6 +2,9 @@ import { NextRequest, NextResponse } from 'next/server'
 import { revalidatePath } from 'next/cache'
 import { createHmac } from 'crypto'
 
+// Force dynamic for webhook endpoint
+export const dynamic = 'force-dynamic'
+
 export async function POST(req: NextRequest) {
   const body = await req.text()
   

--- a/src/lib/basehub.ts
+++ b/src/lib/basehub.ts
@@ -25,7 +25,6 @@ export interface Story {
 export async function getAllStories(): Promise<Story[]> {
   try {
     const data = await basehub({
-      cache: 'force-cache',
       next: { revalidate: 3600 } // Cache for 1 hour
     }).query({
       stories: {
@@ -61,7 +60,6 @@ export async function getAllStories(): Promise<Story[]> {
 export async function getStoryBySlug(slug: string): Promise<Story | null> {
   try {
     const data = await basehub({
-      cache: 'force-cache',
       next: { revalidate: 3600 } // Cache for 1 hour
     }).query({
       stories: {


### PR DESCRIPTION
## Summary
Fixes the Basehub-related errors occurring during Vercel builds while maintaining functionality.

## Issues Fixed
- ❌ **Cache Configuration Conflict**: Removed `cache: force-cache` conflicting with `revalidate: 3600`
- ❌ **Dynamic Server Usage**: Added `dynamic = 'force-dynamic'` to API routes to prevent build-time execution
- ❌ **Build-time API Calls**: Prevented API routes from being called during static generation

## Changes Made
- ✅ **Basehub Config**: Only set global config when `BASEHUB_TOKEN` exists
- ✅ **Cache Strategy**: Use only ISR revalidation (no force-cache conflict)  
- ✅ **API Routes**: Force dynamic rendering to prevent build-time calls
- ✅ **Error Prevention**: Stop "no-store fetch" errors during static generation

## Expected Results
- 🔧 Build warnings eliminated: No more cache configuration conflicts
- 🔧 Dynamic server usage errors resolved
- 🔧 Clean Vercel builds with no Basehub-related errors
- ✅ Functionality preserved: All features still work in production

## Test Plan
- [ ] Verify Vercel build completes without Basehub errors
- [ ] Confirm API endpoints work in production  
- [ ] Test webhook functionality still works
- [ ] Validate story pages load correctly

🤖 Generated with [Claude Code](https://claude.ai/code)