### PR TITLE
Centralize Next.js metadata

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,10 +1,23 @@
 import type { Metadata } from 'next';
+import { defaultMetadata } from '@/lib/seo';
 
 export const metadata: Metadata = {
+  ...defaultMetadata,
   title: 'About',
   description: 'Learn about Classical Virtues',
   alternates: {
     canonical: '/about',
+  },
+  openGraph: {
+    ...defaultMetadata.openGraph,
+    title: 'About',
+    description: 'Learn about Classical Virtues',
+    url: 'https://classicalvirtues.com/about',
+  },
+  twitter: {
+    ...defaultMetadata.twitter,
+    title: 'About',
+    description: 'Learn about Classical Virtues',
   },
 };
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,69 +1,12 @@
-import type { Metadata } from "next";
-import { Analytics } from "@vercel/analytics/react"
-import { cn } from '@/lib/utils'
-import ErrorBoundary from '@/components/ErrorBoundary'
-import './globals.css'
-import { fontHeading, fontBody } from '@/lib/fonts'
+import type { Metadata } from 'next';
+import { Analytics } from '@vercel/analytics/react';
+import { cn } from '@/lib/utils';
+import ErrorBoundary from '@/components/ErrorBoundary';
+import './globals.css';
+import { fontHeading, fontBody } from '@/lib/fonts';
+import { defaultMetadata } from '@/lib/seo';
 
-export const metadata: Metadata = {
-  metadataBase: new URL('https://classicalvirtues.com'),
-  title: {
-    default: "Classical Virtues | Timeless Stories of Character",
-    template: "%s | Classical Virtues"
-  },
-  description: "Discover timeless virtues through classical stories. Our collection of moral tales teaches enduring values of character, ethics, and wisdom for modern times.",
-  keywords: [
-    "virtues",
-    "classical stories",
-    "moral stories",
-    "ethics",
-    "character building",
-    "wisdom tales",
-    "moral education",
-    "virtue stories",
-    "character development",
-    "traditional values"
-  ],
-  authors: [{ name: "Classical Virtues" }],
-  creator: "Classical Virtues",
-  publisher: "Classical Virtues",
-  openGraph: {
-    type: "website",
-    locale: "en_US",
-    url: "https://classicalvirtues.com",
-    siteName: "Classical Virtues",
-    title: "Classical Virtues | Timeless Stories of Character",
-    description: "Discover timeless virtues through classical stories. Our collection of moral tales teaches enduring values of character, ethics, and wisdom for modern times.",
-    images: [{
-      url: "/api/og",
-      width: 1200,
-      height: 630,
-      alt: "Classical Virtues - Timeless Stories of Character"
-    }]
-  },
-  twitter: {
-    card: "summary_large_image",
-    title: "Classical Virtues | Timeless Stories of Character",
-    description: "Discover timeless virtues through classical stories. Our collection of moral tales teaches enduring values of character, ethics, and wisdom for modern times.",
-    images: ["/api/og"],
-    creator: "@classicalvirtues"
-  },
-  robots: {
-    index: true,
-    follow: true,
-    googleBot: {
-      index: true,
-      follow: true,
-      'max-video-preview': -1,
-      'max-image-preview': 'large',
-      'max-snippet': -1,
-    },
-  },
-  alternates: {
-    canonical: '/',
-  },
-  manifest: '/manifest.json'
-}
+export const metadata: Metadata = { ...defaultMetadata };
 
 interface SchemaData {
   '@context': string;
@@ -78,15 +21,16 @@ const JsonLd = ({ data }: { data: SchemaData }) => (
     type="application/ld+json"
     dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
   />
-)
+);
 
 const websiteSchema: SchemaData = {
-  "@context": "https://schema.org",
-  "@type": "WebSite",
-  "name": "Classical Virtues",
-  "url": "https://classicalvirtues.com",
-  "description": "Discover timeless virtues through classical stories. Our collection of moral tales teaches enduring values of character, ethics, and wisdom for modern times."
-}
+  '@context': 'https://schema.org',
+  '@type': 'WebSite',
+  name: 'Classical Virtues',
+  url: 'https://classicalvirtues.com',
+  description:
+    'Discover timeless virtues through classical stories. Our collection of moral tales teaches enduring values of character, ethics, and wisdom for modern times.',
+};
 
 export default function RootLayout({
   children,
@@ -95,16 +39,16 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={cn(
-        'min-h-screen bg-background font-body antialiased',
-        fontHeading.variable,
-        fontBody.variable,
-        fontHeading.className || 'font-serif',
-        fontBody.className || 'font-sans'
-      )}>
-        <ErrorBoundary>
-          {children}
-        </ErrorBoundary>
+      <body
+        className={cn(
+          'min-h-screen bg-background font-body antialiased',
+          fontHeading.variable,
+          fontBody.variable,
+          fontHeading.className || 'font-serif',
+          fontBody.className || 'font-sans'
+        )}
+      >
+        <ErrorBoundary>{children}</ErrorBoundary>
         <Analytics />
         <JsonLd data={websiteSchema} />
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,14 @@
-import SummaryCard from "@/components/summaryCard";
-import { getAllStories } from "@/lib/stories";
-import type { Metadata } from 'next'
+import SummaryCard from '@/components/summaryCard';
+import { getAllStories } from '@/lib/stories';
+import type { Metadata } from 'next';
+import { defaultMetadata } from '@/lib/seo';
 
 export const metadata: Metadata = {
+  ...defaultMetadata,
   alternates: {
     canonical: '/',
   },
-}
+};
 
 // Use BaseHub's built-in caching
 
@@ -17,7 +19,9 @@ export default async function Home() {
     <div className="flex flex-col items-center justify-center min-h-screen bg-background p-4">
       <div className="max-w-5xl w-full space-y-8">
         <header className="text-center space-y-4">
-          <h1 className="text-4xl font-bold tracking-tighter">Classical Virtues</h1>
+          <h1 className="text-4xl font-bold tracking-tighter">
+            Classical Virtues
+          </h1>
           <p className="text-muted-foreground text-lg">
             Timeless virtues taught through tales from the past.
           </p>
@@ -25,7 +29,7 @@ export default async function Home() {
 
         <main className="space-y-8">
           <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
-            {stories.map((story) => (
+            {stories.map(story => (
               <SummaryCard
                 key={story.id}
                 fileName={story.slug}

--- a/src/app/stories/[slug]/page.tsx
+++ b/src/app/stories/[slug]/page.tsx
@@ -7,69 +7,82 @@ import remarkGfm from 'remark-gfm';
 import Image from 'next/image';
 import { Card, CardContent } from '@/components/ui/card';
 import Breadcrumbs from '@/components/Breadcrumbs';
-import type { Metadata } from 'next'
+import type { Metadata } from 'next';
+import { defaultMetadata } from '@/lib/seo';
 
 // Lazy load the AudioPlayer
-const AudioPlayer = dynamic(
-  () => import('@/components/AudioPlayer'),
-  {
-    loading: () => (
-      <Card className="my-8 p-4 bg-transparent w-full border">
-        <h2 className="text-2xl font-bold mb-1 font-heading">Listen to the Story</h2>
-        <div className="bg-background rounded-lg p-4 w-full h-[100px] animate-pulse" />
-      </Card>
-    ),
-    ssr: false // Disable SSR for audio player
-  }
-);
+const AudioPlayer = dynamic(() => import('@/components/AudioPlayer'), {
+  loading: () => (
+    <Card className="my-8 p-4 bg-transparent w-full border">
+      <h2 className="text-2xl font-bold mb-1 font-heading">
+        Listen to the Story
+      </h2>
+      <div className="bg-background rounded-lg p-4 w-full h-[100px] animate-pulse" />
+    </Card>
+  ),
+  ssr: false, // Disable SSR for audio player
+});
 
 export async function generateStaticParams() {
   const stories = await getAllStories();
-  return stories.map((story) => ({
+  return stories.map(story => ({
     slug: story.slug,
   }));
 }
 
-export async function generateMetadata({ params }: { params: { slug: string } }): Promise<Metadata> {
-  const story = await getStoryBySlug(params.slug)
-  
+export async function generateMetadata({
+  params,
+}: {
+  params: { slug: string };
+}): Promise<Metadata> {
+  const story = await getStoryBySlug(params.slug);
+
   if (!story) {
     return {
       title: 'Story Not Found',
-      description: 'The requested story could not be found.'
-    }
+      description: 'The requested story could not be found.',
+    };
   }
 
-  const ogImage = `/api/og?title=${encodeURIComponent(story.title)}&virtue=${encodeURIComponent(story.virtueDescription)}`
+  const ogImage = `/api/og?title=${encodeURIComponent(story.title)}&virtue=${encodeURIComponent(story.virtueDescription)}`;
 
   return {
+    ...defaultMetadata,
     title: story.title,
     description: story.summary,
     alternates: {
       canonical: `/stories/${params.slug}`,
     },
-    keywords: [story.virtue, 'virtue', 'moral story', 'classical virtues'],
+    keywords: [
+      ...(defaultMetadata.keywords || []),
+      story.virtue,
+      'virtue',
+      'moral story',
+      'classical virtues',
+    ],
     openGraph: {
+      ...defaultMetadata.openGraph,
       type: 'article',
       url: `https://classicalvirtues.com/stories/${params.slug}`,
       title: story.title,
       description: story.summary,
-      images: [{
-        url: ogImage,
-        width: 1200,
-        height: 630,
-        alt: story.title
-      }],
-      siteName: 'Classical Virtues',
+      images: [
+        {
+          url: ogImage,
+          width: 1200,
+          height: 630,
+          alt: story.title,
+        },
+      ],
       publishedTime: new Date().toISOString(),
     },
     twitter: {
-      card: 'summary_large_image',
+      ...defaultMetadata.twitter,
       title: story.title,
       description: story.summary,
-      images: [ogImage]
-    }
-  }
+      images: [ogImage],
+    },
+  };
 }
 
 interface JsonLdProps {
@@ -96,7 +109,7 @@ interface JsonLdProps {
       '@type': string;
       '@id': string;
     };
-  }
+  };
 }
 
 const JsonLd = ({ data }: JsonLdProps) => (
@@ -104,7 +117,7 @@ const JsonLd = ({ data }: JsonLdProps) => (
     type="application/ld+json"
     dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
   />
-)
+);
 
 // Use BaseHub's built-in caching
 
@@ -116,43 +129,45 @@ export default async function Post({ params }: { params: { slug: string } }) {
   }
 
   const articleStructuredData = {
-    "@context": "https://schema.org",
-    "@type": "Article",
-    "headline": story.title,
-    "description": story.summary,
-    "image": story.image.startsWith('http') ? story.image : `https://classicalvirtues.com${story.image}`,
-    "wordCount": story.wordCount,
-    "author": {
-      "@type": "Organization",
-      "name": "Classical Virtues",
-      "url": "https://classicalvirtues.com"
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: story.title,
+    description: story.summary,
+    image: story.image.startsWith('http')
+      ? story.image
+      : `https://classicalvirtues.com${story.image}`,
+    wordCount: story.wordCount,
+    author: {
+      '@type': 'Organization',
+      name: 'Classical Virtues',
+      url: 'https://classicalvirtues.com',
     },
-    "publisher": {
-      "@type": "Organization",
-      "name": "Classical Virtues",
-      "url": "https://classicalvirtues.com",
-      "logo": {
-        "@type": "ImageObject",
-        "url": "https://classicalvirtues.com/logo.png"
-      }
+    publisher: {
+      '@type': 'Organization',
+      name: 'Classical Virtues',
+      url: 'https://classicalvirtues.com',
+      logo: {
+        '@type': 'ImageObject',
+        url: 'https://classicalvirtues.com/logo.png',
+      },
     },
-    "datePublished": new Date().toISOString(),
-    "dateModified": new Date().toISOString(),
-    "mainEntityOfPage": {
-      "@type": "WebPage",
-      "@id": `https://classicalvirtues.com/stories/${params.slug}`
+    datePublished: new Date().toISOString(),
+    dateModified: new Date().toISOString(),
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': `https://classicalvirtues.com/stories/${params.slug}`,
     },
-    "articleSection": "Moral Stories",
-    "keywords": [story.virtue, "virtue", "moral story", "classical virtues"],
+    articleSection: 'Moral Stories',
+    keywords: [story.virtue, 'virtue', 'moral story', 'classical virtues'],
     ...(story.audioUrl
       ? {
-          "audio": {
-            "@type": "AudioObject",
-            "contentUrl": story.audioUrl,
+          audio: {
+            '@type': 'AudioObject',
+            contentUrl: story.audioUrl,
           },
         }
-      : {})
-  }
+      : {}),
+  };
 
   return (
     <div className="max-w-3xl mx-auto py-8 px-4 sm:px-6 lg:px-8">
@@ -167,13 +182,21 @@ export default async function Post({ params }: { params: { slug: string } }) {
         />
       </div>
       {story.audioUrl && (
-        <Suspense fallback={
-          <Card className="my-8 p-4 bg-transparent w-full border">
-            <h2 className="text-2xl font-bold mb-1 font-heading">Listen to the Story</h2>
-            <div className="bg-background rounded-lg p-4 w-full h-[100px] animate-pulse" />
-          </Card>
-        }>
-          <AudioPlayer audioUrl={story.audioUrl} title={story.title} image={story.image} />
+        <Suspense
+          fallback={
+            <Card className="my-8 p-4 bg-transparent w-full border">
+              <h2 className="text-2xl font-bold mb-1 font-heading">
+                Listen to the Story
+              </h2>
+              <div className="bg-background rounded-lg p-4 w-full h-[100px] animate-pulse" />
+            </Card>
+          }
+        >
+          <AudioPlayer
+            audioUrl={story.audioUrl}
+            title={story.title}
+            image={story.image}
+          />
         </Suspense>
       )}
       <h1 className="text-4xl font-bold mb-4 font-heading">{story.title}</h1>
@@ -193,7 +216,9 @@ export default async function Post({ params }: { params: { slug: string } }) {
         <CardContent className="p-8">
           <div className="space-y-6">
             <div className="flex items-baseline ">
-              <span className="font-heading font-semibold text-2xl">Moral Of The Story</span>
+              <span className="font-heading font-semibold text-2xl">
+                Moral Of The Story
+              </span>
             </div>
             <div className="border-t border-accent-foreground/20 pt-4">
               <p className="font-heading text-lg italic leading-relaxed">

--- a/src/app/stories/page.tsx
+++ b/src/app/stories/page.tsx
@@ -1,35 +1,51 @@
-import SummaryCard from '@/components/summaryCard'
-import { getAllStories } from '@/lib/stories'
-import type { Metadata } from 'next'
+import SummaryCard from '@/components/summaryCard';
+import { getAllStories } from '@/lib/stories';
+import type { Metadata } from 'next';
+import { defaultMetadata } from '@/lib/seo';
 
 export const metadata: Metadata = {
+  ...defaultMetadata,
   title: 'Stories',
   description: 'Browse all classical virtue stories',
   alternates: {
     canonical: '/stories',
   },
-}
+  openGraph: {
+    ...defaultMetadata.openGraph,
+    title: 'Stories',
+    description: 'Browse all classical virtue stories',
+    url: 'https://classicalvirtues.com/stories',
+  },
+  twitter: {
+    ...defaultMetadata.twitter,
+    title: 'Stories',
+    description: 'Browse all classical virtue stories',
+  },
+};
 
 // Use BaseHub's built-in caching
 
 export default async function StoriesIndex() {
-  const stories = await getAllStories()
+  const stories = await getAllStories();
 
   return (
     <div className="max-w-4xl mx-auto py-8 px-4 space-y-6">
       <h1 className="text-4xl font-heading font-bold mb-4">Stories</h1>
-      <p className="text-muted-foreground mb-8">Discover our collection of timeless stories, each highlighting a unique virtue.</p>
+      <p className="text-muted-foreground mb-8">
+        Discover our collection of timeless stories, each highlighting a unique
+        virtue.
+      </p>
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
         {stories.map(story => (
-          <SummaryCard 
-            key={story.id} 
-            fileName={`${story.slug}.mdx`} 
-            image={story.image} 
-            title={story.title} 
-            summary={story.summary} 
+          <SummaryCard
+            key={story.id}
+            fileName={`${story.slug}.mdx`}
+            image={story.image}
+            title={story.title}
+            summary={story.summary}
           />
         ))}
       </div>
     </div>
-  )
+  );
 }

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,66 @@
+import type { Metadata } from 'next';
+
+export const defaultMetadata: Metadata = {
+  metadataBase: new URL('https://classicalvirtues.com'),
+  title: {
+    default: 'Classical Virtues | Timeless Stories of Character',
+    template: '%s | Classical Virtues',
+  },
+  description:
+    'Discover timeless virtues through classical stories. Our collection of moral tales teaches enduring values of character, ethics, and wisdom for modern times.',
+  keywords: [
+    'virtues',
+    'classical stories',
+    'moral stories',
+    'ethics',
+    'character building',
+    'wisdom tales',
+    'moral education',
+    'virtue stories',
+    'character development',
+    'traditional values',
+  ],
+  authors: [{ name: 'Classical Virtues' }],
+  creator: 'Classical Virtues',
+  publisher: 'Classical Virtues',
+  openGraph: {
+    type: 'website',
+    locale: 'en_US',
+    url: 'https://classicalvirtues.com',
+    siteName: 'Classical Virtues',
+    title: 'Classical Virtues | Timeless Stories of Character',
+    description:
+      'Discover timeless virtues through classical stories. Our collection of moral tales teaches enduring values of character, ethics, and wisdom for modern times.',
+    images: [
+      {
+        url: '/api/og',
+        width: 1200,
+        height: 630,
+        alt: 'Classical Virtues - Timeless Stories of Character',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Classical Virtues | Timeless Stories of Character',
+    description:
+      'Discover timeless virtues through classical stories. Our collection of moral tales teaches enduring values of character, ethics, and wisdom for modern times.',
+    images: ['/api/og'],
+    creator: '@classicalvirtues',
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      'max-video-preview': -1,
+      'max-image-preview': 'large',
+      'max-snippet': -1,
+    },
+  },
+  alternates: {
+    canonical: '/',
+  },
+  manifest: '/manifest.json',
+};

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 
-export const defaultMetadata: Metadata = {
+export const defaultMetadata = {
   metadataBase: new URL('https://classicalvirtues.com'),
   title: {
     default: 'Classical Virtues | Timeless Stories of Character',
@@ -63,4 +63,4 @@ export const defaultMetadata: Metadata = {
     canonical: '/',
   },
   manifest: '/manifest.json',
-};
+} satisfies Metadata;


### PR DESCRIPTION
## Summary
- add SEO defaults helper
- reuse helper in layout and pages via spread syntax
- extend defaults in dynamic metadata

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_688272ad699c832d9f22d2669b264aa8