### PR TITLE
PRO-21: Per-story SEO audit + restrained share affordance

### DIFF
--- a/src/app/stories/[slug]/page.tsx
+++ b/src/app/stories/[slug]/page.tsx
@@ -8,6 +8,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import Breadcrumbs from '@/components/Breadcrumbs';
 import JsonLd from '@/components/JsonLd';
 import LazyAudioPlayer from '@/components/LazyAudioPlayer';
+import ShareStory from '@/components/ShareStory';
 import { notFound } from 'next/navigation';
 import type { Metadata } from 'next'
 import type { ReactNode } from 'react'
@@ -182,6 +183,7 @@ export default async function Post({ params }: { params: Params }) {
           </div>
         </CardContent>
       </Card>
+      <ShareStory title={story.title} slug={slug} />
       {relatedStories.length > 0 && (
         <section aria-labelledby="read-another" className="mt-16 border-t border-border pt-10">
           <h2 id="read-another" className="font-heading text-2xl mb-6">Read another story</h2>

--- a/src/components/ShareStory.tsx
+++ b/src/components/ShareStory.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+
+type ShareState = 'idle' | 'copied';
+
+/**
+ * A restrained share affordance for story pages. On devices with the native
+ * share sheet (mostly mobile) it opens that; everywhere else it copies the
+ * link and quietly confirms. No counts, no logos, no "share to X" — just a
+ * way to pass a story along.
+ */
+export default function ShareStory({ title, slug }: { title: string; slug: string }) {
+  const [state, setState] = useState<ShareState>('idle');
+
+  const url = `https://classicalvirtues.com/stories/${slug}`;
+
+  // Reset the "Link copied" confirmation after a short, calm pause.
+  useEffect(() => {
+    if (state !== 'copied') return;
+    const timer = setTimeout(() => setState('idle'), 2500);
+    return () => clearTimeout(timer);
+  }, [state]);
+
+  async function handleShare() {
+    if (typeof navigator !== 'undefined' && typeof navigator.share === 'function') {
+      try {
+        await navigator.share({ title, text: `“${title}” — a story from Classical Virtues`, url });
+        return;
+      } catch {
+        // The reader dismissed the sheet, or it failed. Fall through to copy.
+      }
+    }
+
+    try {
+      await navigator.clipboard.writeText(url);
+      setState('copied');
+    } catch {
+      // Clipboard unavailable (e.g. insecure context). Leave the label as-is.
+    }
+  }
+
+  const label = state === 'copied' ? 'Link copied' : 'Share this story';
+
+  return (
+    <div className="mt-12 flex justify-center">
+      <button
+        type="button"
+        onClick={handleShare}
+        aria-live="polite"
+        className="text-sm text-muted-foreground underline underline-offset-4 decoration-muted-foreground/40 hover:text-foreground hover:decoration-foreground transition-colors py-2"
+      >
+        {label}
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Closes the PRO-21 (Track 3 — Reach & discovery) scope.

**Audit result — already in good shape, verified per-story:**
- Per-story `<title>`, description, canonical, keywords via `generateMetadata` (`src/app/stories/[slug]/page.tsx`).
- OpenGraph (`type: article`, per-story dynamic OG image via `/api/og`) and Twitter `summary_large_image` cards, all per-story.
- JSON-LD: per-story **Article** (with `wordCount`, `audio`, publisher/logo) and **BreadcrumbList** (`src/components/Breadcrumbs.tsx`).
- `metadataBase` set in root layout so relative OG image URLs resolve.
- Dynamic `sitemap.ts` includes home, `/stories`, `/about`, and **every** story URL. There are no separate virtue routes in the app (virtue is a story attribute, not its own page), so there are no virtue URLs to add — noted for the record.

**New work — share affordance:**
- `src/components/ShareStory.tsx`: a single, quiet "Share this story" text link centered below the story. Uses the native Web Share sheet where available, otherwise copies the link and shows a calm "Link copied" confirmation. No share counts, network logos, or per-platform buttons — consistent with the anti-references in §9.

## Verification
- `pnpm run lint` — clean
- `npx tsc --noEmit` — clean
- `npx next build` — compiles successfully; story route builds (Basehub fetch warnings are the expected token-less graceful degradation in CI, not from this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)