### PR TITLE
Reading-experience polish: audio screen-reader state + play-control emphasis (PRO-20)

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -88,16 +88,19 @@ export default function AudioPlayer({ audioUrl, title, image }: AudioPlayerProps
     };
 
     const handlePlay = () => {
+      // The 'play' event fires on intent; audio may still be buffering, so
+      // hold the spoken status at "Loading…" until 'playing' confirms sound.
       setIsPlaying(true);
-      setStatus('Playing');
     };
 
     const handlePlaying = () => {
       setIsBuffering(false);
+      setStatus('Playing');
     };
 
     const handleWaiting = () => {
       setIsBuffering(true);
+      setStatus('Loading…');
     };
 
     const handleCanPlay = () => {
@@ -214,6 +217,7 @@ export default function AudioPlayer({ audioUrl, title, image }: AudioPlayerProps
 
     try {
       setIsBuffering(true);
+      setStatus('Loading…');
       await audio.play();
     } catch (playError) {
       console.error('Playback failed:', playError);
@@ -273,9 +277,9 @@ export default function AudioPlayer({ audioUrl, title, image }: AudioPlayerProps
                 aria-hidden="true"
               />
             ) : isPlaying ? (
-              <PauseIcon className="h-5 w-5 text-muted-foreground" aria-hidden="true" />
+              <PauseIcon className="h-5 w-5 text-foreground" aria-hidden="true" />
             ) : (
-              <PlayIcon className="h-5 w-5 text-muted-foreground" aria-hidden="true" />
+              <PlayIcon className="h-5 w-5 text-foreground" aria-hidden="true" />
             )}
           </Button>
           <Button


### PR DESCRIPTION
## Track 2 — Reading-experience polish (PRO-20)

Audited the story reading view against the PRO-20 Done-when criteria. Most of the surface was already solid from the prior redesign (68ch Literata measure, balanced headings, themed prose ink, focus-visible rings, reduced-motion handling, 44px touch targets, media-session lock-screen controls). This PR closes the two genuine gaps I found in the audio player.

### Changes
- **Screen-reader state (§8.5 / WCAG 2.1 AA):** the polite live region announced Play/Pause/Finish but never the loading/buffering state, and the `play` event prematurely announced "Playing" while audio was still buffering. Moved "Playing" to the `playing` event (fires when sound actually starts) and announce "Loading…" on play intent and on `waiting`. An SR user who presses play now hears accurate state.
- **One-handed glanceability:** the primary play/pause icon rendered in `muted-foreground` — same emphasis as the secondary skip controls. Gave it full `foreground` ink for clear visual hierarchy; skip and spinner icons stay quiet, preserving the restrained palette.

### Verification
- `tsc --noEmit` — clean
- `eslint src/components/AudioPlayer.tsx` — clean
- Live-region trace reviewed: idle → "Loading…" (play intent / waiting) → "Playing" (playing) → "Paused" / "Finished"; errors still take precedence via `error ?? status`.

### Done-when status
- ✅ Page reads like a book — 68ch Literata measure, balanced display headings, warm themed ink (prior redesign, unchanged).
- ✅ Audio passes keyboard check — real `<button>`s + Radix slider (arrow-seek), visible focus rings, 44px targets.
- ✅ Audio passes screen-reader check — labelled controls, slider `aria-valuetext` ("1:05 of 3:30"), and now accurate loading/playing/paused/finished announcements.
- ✅ One-handed on a phone — 44px controls, reachable layout, OS lock-screen/notification controls via Media Session, clearer primary affordance.
- ✅ Reduced motion + focus states hold — global `prefers-reduced-motion` block, `motion-reduce:animate-none` spinner, global `:focus-visible` outline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)