### PR TITLE
PRO-19: Stand up the seven-virtue canon and render it on the site

### DIFF
--- a/basehub-types.d.ts
+++ b/basehub-types.d.ts
@@ -118,7 +118,7 @@ export interface BlockColor {
     __typename: 'BlockColor'
 }
 
-export type BlockDocument = (About | Stories | StoriesItem | Workflows | _AgentStart | storiesItem_AsList) & { __isUnion?: true }
+export type BlockDocument = (About | Stories | StoriesItem | Virtues | VirtuesItem | Workflows | _AgentStart | storiesItem_AsList | virtuesItem_AsList) & { __isUnion?: true }
 
 export interface BlockDocumentSys {
     apiNamePath: Scalars['String']
@@ -177,7 +177,7 @@ export interface BlockImage {
     __typename: 'BlockImage'
 }
 
-export type BlockList = (Stories | storiesItem_AsList) & { __isUnion?: true }
+export type BlockList = (Stories | Virtues | storiesItem_AsList | virtuesItem_AsList) & { __isUnion?: true }
 
 export interface BlockOgImage {
     height: Scalars['Int']
@@ -188,7 +188,7 @@ export interface BlockOgImage {
 
 
 /** Rich text block */
-export type BlockRichText = (Content | Content_1) & { __isUnion?: true }
+export type BlockRichText = (Content | Content_1 | Description) & { __isUnion?: true }
 
 export interface BlockVideo {
     aspectRatio: Scalars['String']
@@ -232,6 +232,21 @@ export interface Content_1RichText {
     content: Scalars['BSHBRichTextContentSchema']
     toc: Scalars['BSHBRichTextTOCSchema']
     __typename: 'Content_1RichText'
+}
+
+export interface Description {
+    html: Scalars['String']
+    json: DescriptionRichText
+    markdown: Scalars['String']
+    plainText: Scalars['String']
+    readingTime: Scalars['Int']
+    __typename: 'Description'
+}
+
+export interface DescriptionRichText {
+    content: Scalars['BSHBRichTextContentSchema']
+    toc: Scalars['BSHBRichTextTOCSchema']
+    __typename: 'DescriptionRichText'
 }
 
 export interface GetUploadSignedURL {
@@ -298,6 +313,7 @@ export interface Query {
     _sys: RepoSys
     about: About
     stories: Stories
+    virtues: Virtues
     workflows: Workflows
     __typename: 'Query'
 }
@@ -314,7 +330,7 @@ export interface RepoSys {
     __typename: 'RepoSys'
 }
 
-export type RichTextJson = (BaseRichTextJson | ContentRichText | Content_1RichText) & { __isUnion?: true }
+export type RichTextJson = (BaseRichTextJson | ContentRichText | Content_1RichText | DescriptionRichText) & { __isUnion?: true }
 
 export interface SearchHighlight {
     /** The field/path that was matched (e.g., "title", "body.content") */
@@ -392,6 +408,45 @@ export interface Variant {
     label: Scalars['String']
     __typename: 'Variant'
 }
+
+export interface Virtues {
+    _analyticsKey: Scalars['String']
+    _dashboardUrl: Scalars['String']
+    _id: Scalars['String']
+    _idPath: Scalars['String']
+    _meta: ListMeta
+    /** The key used to search from the frontend. */
+    _searchKey: Scalars['String']
+    _slug: Scalars['String']
+    _slugPath: Scalars['String']
+    _sys: BlockDocumentSys
+    _title: Scalars['String']
+    /** Returns the first item in the list, or null if the list is empty. Useful when you expect only one result. */
+    item: (VirtuesItem | null)
+    /** Returns the list of items after filtering and paginating according to the arguments sent by the client. */
+    items: VirtuesItem[]
+    __typename: 'Virtues'
+}
+
+export interface VirtuesItem {
+    _analyticsKey: Scalars['String']
+    _dashboardUrl: Scalars['String']
+    /** Array of search highlight information with field names and HTML markup */
+    _highlight: (SearchHighlight[] | null)
+    _id: Scalars['String']
+    _idPath: Scalars['String']
+    _slug: Scalars['String']
+    _slugPath: Scalars['String']
+    _sys: BlockDocumentSys
+    _title: Scalars['String']
+    alternateName: (Scalars['String'] | null)
+    description: (Description | null)
+    order: (Scalars['Float'] | null)
+    tagline: (Scalars['String'] | null)
+    __typename: 'VirtuesItem'
+}
+
+export type VirtuesItemOrderByEnum = '_sys_createdAt__ASC' | '_sys_createdAt__DESC' | '_sys_hash__ASC' | '_sys_hash__DESC' | '_sys_id__ASC' | '_sys_id__DESC' | '_sys_lastModifiedAt__ASC' | '_sys_lastModifiedAt__DESC' | '_sys_slug__ASC' | '_sys_slug__DESC' | '_sys_title__ASC' | '_sys_title__DESC' | 'alternateName__ASC' | 'alternateName__DESC' | 'description__ASC' | 'description__DESC' | 'order__ASC' | 'order__DESC' | 'tagline__ASC' | 'tagline__DESC'
 
 export interface Workflows {
     _analyticsKey: Scalars['String']
@@ -507,6 +562,7 @@ export interface _agents {
 
 export interface _components {
     storiesItem: storiesItem_AsList
+    virtuesItem: virtuesItem_AsList
     __typename: '_components'
 }
 
@@ -527,6 +583,25 @@ export interface storiesItem_AsList {
     /** Returns the list of items after filtering and paginating according to the arguments sent by the client. */
     items: StoriesItem[]
     __typename: 'storiesItem_AsList'
+}
+
+export interface virtuesItem_AsList {
+    _analyticsKey: Scalars['String']
+    _dashboardUrl: Scalars['String']
+    _id: Scalars['String']
+    _idPath: Scalars['String']
+    _meta: ListMeta
+    /** The key used to search from the frontend. */
+    _searchKey: Scalars['String']
+    _slug: Scalars['String']
+    _slugPath: Scalars['String']
+    _sys: BlockDocumentSys
+    _title: Scalars['String']
+    /** Returns the first item in the list, or null if the list is empty. Useful when you expect only one result. */
+    item: (VirtuesItem | null)
+    /** Returns the list of items after filtering and paginating according to the arguments sent by the client. */
+    items: VirtuesItem[]
+    __typename: 'virtuesItem_AsList'
 }
 
 export interface AboutGenqlSelection{
@@ -611,9 +686,12 @@ export interface BlockDocumentGenqlSelection{
     on_About?: AboutGenqlSelection
     on_Stories?: StoriesGenqlSelection
     on_StoriesItem?: StoriesItemGenqlSelection
+    on_Virtues?: VirtuesGenqlSelection
+    on_VirtuesItem?: VirtuesItemGenqlSelection
     on_Workflows?: WorkflowsGenqlSelection
     on__AgentStart?: _AgentStartGenqlSelection
     on_storiesItem_AsList?: storiesItem_AsListGenqlSelection
+    on_virtuesItem_AsList?: virtuesItem_AsListGenqlSelection
     __typename?: boolean | number
     __fragmentOn?: "BlockDocument"
 }
@@ -697,7 +775,9 @@ export interface BlockListGenqlSelection{
     _sys?: BlockDocumentSysGenqlSelection
     _title?: boolean | number
     on_Stories?: StoriesGenqlSelection
+    on_Virtues?: VirtuesGenqlSelection
     on_storiesItem_AsList?: storiesItem_AsListGenqlSelection
+    on_virtuesItem_AsList?: virtuesItem_AsListGenqlSelection
     __typename?: boolean | number
     __fragmentOn?: "BlockList"
 }
@@ -726,6 +806,7 @@ export interface BlockRichTextGenqlSelection{
     wpm?: (Scalars['Int'] | null)} } | boolean | number
     on_Content?: ContentGenqlSelection
     on_Content_1?: Content_1GenqlSelection
+    on_Description?: DescriptionGenqlSelection
     __typename?: boolean | number
     __fragmentOn?: "BlockRichText"
 }
@@ -792,6 +873,29 @@ export interface Content_1RichTextGenqlSelection{
 }
 
 export interface DateFilter {eq?: (Scalars['DateTime'] | null),isAfter?: (Scalars['DateTime'] | null),isBefore?: (Scalars['DateTime'] | null),isNull?: (Scalars['Boolean'] | null),neq?: (Scalars['DateTime'] | null),onOrAfter?: (Scalars['DateTime'] | null),onOrBefore?: (Scalars['DateTime'] | null)}
+
+export interface DescriptionGenqlSelection{
+    html?: { __args: {
+    /** It automatically generates a unique id for each heading present in the HTML. Enabled by default. */
+    slugs?: (Scalars['Boolean'] | null), 
+    /** Inserts a table of contents at the beginning of the HTML. */
+    toc?: (Scalars['Boolean'] | null)} } | boolean | number
+    json?: DescriptionRichTextGenqlSelection
+    markdown?: boolean | number
+    plainText?: boolean | number
+    readingTime?: { __args: {
+    /** Words per minute, defaults to average 183wpm */
+    wpm?: (Scalars['Int'] | null)} } | boolean | number
+    __typename?: boolean | number
+    __fragmentOn?: "Description"
+}
+
+export interface DescriptionRichTextGenqlSelection{
+    content?: boolean | number
+    toc?: boolean | number
+    __typename?: boolean | number
+    __fragmentOn?: "DescriptionRichText"
+}
 
 export interface GetUploadSignedURLGenqlSelection{
     signedURL?: boolean | number
@@ -934,6 +1038,17 @@ export interface QueryGenqlSelection{
     search?: (StoriesItemSearchInput | null), 
     /** Skip the first n items. */
     skip?: (Scalars['Int'] | null)} })
+    virtues?: (VirtuesGenqlSelection & { __args?: {
+    /** Filter by a field. */
+    filter?: (VirtuesItemFilterInput | null), 
+    /** Limit the number of items returned. Defaults to 500. */
+    first?: (Scalars['Int'] | null), 
+    /** Order by a field. */
+    orderBy?: (VirtuesItemOrderByEnum | null), 
+    /** Search configuration */
+    search?: (VirtuesItemSearchInput | null), 
+    /** Skip the first n items. */
+    skip?: (Scalars['Int'] | null)} })
     workflows?: WorkflowsGenqlSelection
     __typename?: boolean | number
     __fragmentOn?: "Query"
@@ -958,6 +1073,7 @@ export interface RichTextJsonGenqlSelection{
     on_BaseRichTextJson?: BaseRichTextJsonGenqlSelection
     on_ContentRichText?: ContentRichTextGenqlSelection
     on_Content_1RichText?: Content_1RichTextGenqlSelection
+    on_DescriptionRichText?: DescriptionRichTextGenqlSelection
     __typename?: boolean | number
     __fragmentOn?: "RichTextJson"
 }
@@ -1068,6 +1184,65 @@ export interface VariantGenqlSelection{
     __typename?: boolean | number
     __fragmentOn?: "Variant"
 }
+
+export interface VirtuesGenqlSelection{
+    _analyticsKey?: { __args: {
+    /**
+     * The scope of the analytics key. Use `send` for just ingesting data. Use `query` if you need to show an analytics data in your website.
+     * 
+     * Have in mind, if you expose your `query` analytics key in the frontend, you'll be exposing all of this block's analytics data to the public. This is generally safe, but it might not be in your case.
+     */
+    scope?: (AnalyticsKeyScope | null)} } | boolean | number
+    _dashboardUrl?: boolean | number
+    _id?: boolean | number
+    _idPath?: boolean | number
+    _meta?: ListMetaGenqlSelection
+    /** The key used to search from the frontend. */
+    _searchKey?: boolean | number
+    _slug?: boolean | number
+    _slugPath?: boolean | number
+    _sys?: BlockDocumentSysGenqlSelection
+    _title?: boolean | number
+    /** Returns the first item in the list, or null if the list is empty. Useful when you expect only one result. */
+    item?: VirtuesItemGenqlSelection
+    /** Returns the list of items after filtering and paginating according to the arguments sent by the client. */
+    items?: VirtuesItemGenqlSelection
+    __typename?: boolean | number
+    __fragmentOn?: "Virtues"
+}
+
+export interface VirtuesItemGenqlSelection{
+    _analyticsKey?: { __args: {
+    /**
+     * The scope of the analytics key. Use `send` for just ingesting data. Use `query` if you need to show an analytics data in your website.
+     * 
+     * Have in mind, if you expose your `query` analytics key in the frontend, you'll be exposing all of this block's analytics data to the public. This is generally safe, but it might not be in your case.
+     */
+    scope?: (AnalyticsKeyScope | null)} } | boolean | number
+    _dashboardUrl?: boolean | number
+    /** Array of search highlight information with field names and HTML markup */
+    _highlight?: SearchHighlightGenqlSelection
+    _id?: boolean | number
+    _idPath?: boolean | number
+    _slug?: boolean | number
+    _slugPath?: boolean | number
+    _sys?: BlockDocumentSysGenqlSelection
+    _title?: boolean | number
+    alternateName?: boolean | number
+    description?: DescriptionGenqlSelection
+    order?: boolean | number
+    tagline?: boolean | number
+    __typename?: boolean | number
+    __fragmentOn?: "VirtuesItem"
+}
+
+export interface VirtuesItemFilterInput {AND?: (VirtuesItemFilterInput | null),OR?: (VirtuesItemFilterInput | null),_id?: (StringFilter | null),_slug?: (StringFilter | null),_sys_apiNamePath?: (StringFilter | null),_sys_createdAt?: (DateFilter | null),_sys_hash?: (StringFilter | null),_sys_id?: (StringFilter | null),_sys_idPath?: (StringFilter | null),_sys_lastModifiedAt?: (DateFilter | null),_sys_slug?: (StringFilter | null),_sys_slugPath?: (StringFilter | null),_sys_title?: (StringFilter | null),_title?: (StringFilter | null),alternateName?: (StringFilter | null),order?: (NumberFilter | null),tagline?: (StringFilter | null)}
+
+export interface VirtuesItemSearchInput {
+/** Searchable fields for query */
+by?: (Scalars['String'][] | null),
+/** Search query */
+q?: (Scalars['String'] | null)}
 
 export interface WorkflowsGenqlSelection{
     _analyticsKey?: { __args: {
@@ -1209,6 +1384,17 @@ export interface _componentsGenqlSelection{
     search?: (StoriesItemSearchInput | null), 
     /** Skip the first n items. */
     skip?: (Scalars['Int'] | null)} })
+    virtuesItem?: (virtuesItem_AsListGenqlSelection & { __args?: {
+    /** Filter by a field. */
+    filter?: (VirtuesItemFilterInput | null), 
+    /** Limit the number of items returned. Defaults to 500. */
+    first?: (Scalars['Int'] | null), 
+    /** Order by a field. */
+    orderBy?: (VirtuesItemOrderByEnum | null), 
+    /** Search configuration */
+    search?: (VirtuesItemSearchInput | null), 
+    /** Skip the first n items. */
+    skip?: (Scalars['Int'] | null)} })
     __typename?: boolean | number
     __fragmentOn?: "_components"
 }
@@ -1237,6 +1423,32 @@ export interface storiesItem_AsListGenqlSelection{
     items?: StoriesItemGenqlSelection
     __typename?: boolean | number
     __fragmentOn?: "storiesItem_AsList"
+}
+
+export interface virtuesItem_AsListGenqlSelection{
+    _analyticsKey?: { __args: {
+    /**
+     * The scope of the analytics key. Use `send` for just ingesting data. Use `query` if you need to show an analytics data in your website.
+     * 
+     * Have in mind, if you expose your `query` analytics key in the frontend, you'll be exposing all of this block's analytics data to the public. This is generally safe, but it might not be in your case.
+     */
+    scope?: (AnalyticsKeyScope | null)} } | boolean | number
+    _dashboardUrl?: boolean | number
+    _id?: boolean | number
+    _idPath?: boolean | number
+    _meta?: ListMetaGenqlSelection
+    /** The key used to search from the frontend. */
+    _searchKey?: boolean | number
+    _slug?: boolean | number
+    _slugPath?: boolean | number
+    _sys?: BlockDocumentSysGenqlSelection
+    _title?: boolean | number
+    /** Returns the first item in the list, or null if the list is empty. Useful when you expect only one result. */
+    item?: VirtuesItemGenqlSelection
+    /** Returns the list of items after filtering and paginating according to the arguments sent by the client. */
+    items?: VirtuesItemGenqlSelection
+    __typename?: boolean | number
+    __fragmentOn?: "virtuesItem_AsList"
 }
 
 export interface FragmentsMap {
@@ -1308,6 +1520,14 @@ export interface FragmentsMap {
     root: Content_1RichText,
     selection: Content_1RichTextGenqlSelection,
 }
+  Description: {
+    root: Description,
+    selection: DescriptionGenqlSelection,
+}
+  DescriptionRichText: {
+    root: DescriptionRichText,
+    selection: DescriptionRichTextGenqlSelection,
+}
   GetUploadSignedURL: {
     root: GetUploadSignedURL,
     selection: GetUploadSignedURLGenqlSelection,
@@ -1360,6 +1580,14 @@ export interface FragmentsMap {
     root: Variant,
     selection: VariantGenqlSelection,
 }
+  Virtues: {
+    root: Virtues,
+    selection: VirtuesGenqlSelection,
+}
+  VirtuesItem: {
+    root: VirtuesItem,
+    selection: VirtuesItemGenqlSelection,
+}
   Workflows: {
     root: Workflows,
     selection: WorkflowsGenqlSelection,
@@ -1399,5 +1627,9 @@ export interface FragmentsMap {
   storiesItem_AsList: {
     root: storiesItem_AsList,
     selection: storiesItem_AsListGenqlSelection,
+}
+  virtuesItem_AsList: {
+    root: virtuesItem_AsList,
+    selection: virtuesItem_AsListGenqlSelection,
 }
 }

--- a/scripts/seed-virtues.mjs
+++ b/scripts/seed-virtues.mjs
@@ -1,0 +1,96 @@
+// Seed the seven-virtue canon into Basehub (PRO-19).
+//
+// Stands up a `virtues` collection with a component template and one instance
+// per classical virtue (4 cardinal + 3 theological). Idempotent: the collection
+// is keyed on apiName and each row on slug, so re-running updates in place
+// rather than duplicating.
+//
+// The canon itself lives in src/data/virtues.json — the single source of truth
+// shared with the website (src/lib/virtues.ts), so there is no drift.
+//
+// Usage:
+//   BASEHUB_TOKEN must have WRITE scope (an Admin Token). The read token used by
+//   the site at runtime is NOT sufficient. Provide the admin token via the
+//   BASEHUB_ADMIN_TOKEN env var (preferred) or BASEHUB_TOKEN:
+//
+//     BASEHUB_ADMIN_TOKEN=bsh_xxx node --env-file=.env.local scripts/seed-virtues.mjs
+//
+// On success it auto-commits to the Basehub repo and the site's read token will
+// then see the `virtues` collection (run `pnpm basehub` to regenerate types).
+
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { basehub } from 'basehub'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const VIRTUES = JSON.parse(
+  readFileSync(join(__dirname, '..', 'src', 'data', 'virtues.json'), 'utf8'),
+)
+
+function rowFor(v) {
+  return {
+    type: 'instance',
+    title: v.title,
+    slug: v.slug,
+    idempotency: { key: 'slug', value: v.slug },
+    value: {
+      order: { type: 'number', value: v.order },
+      tagline: { type: 'text', value: v.tagline },
+      alternateName: { type: 'text', value: v.alternateName ?? '' },
+      description: {
+        type: 'rich-text',
+        value: { format: 'markdown', value: v.description },
+      },
+    },
+  }
+}
+
+const transaction = [
+  {
+    type: 'collection',
+    title: 'Virtues',
+    apiName: 'virtues',
+    description: 'The seven classical virtues — each a home for the stories that teach it.',
+    idempotency: { key: 'apiName', value: 'virtues' },
+    template: [
+      { type: 'number', title: 'Order', apiName: 'order' },
+      { type: 'text', title: 'Tagline', apiName: 'tagline' },
+      { type: 'text', title: 'Alternate Name', apiName: 'alternateName' },
+      { type: 'rich-text', title: 'Description', apiName: 'description' },
+    ],
+    rows: VIRTUES.map(rowFor),
+  },
+]
+
+async function main() {
+  const token = process.env.BASEHUB_ADMIN_TOKEN || process.env.BASEHUB_TOKEN
+  if (!token) {
+    console.error('✗ No token. Set BASEHUB_ADMIN_TOKEN (write scope) and rerun.')
+    process.exit(1)
+  }
+
+  console.log(`Seeding ${VIRTUES.length} virtues into Basehub…`)
+  const { transaction: result } = await basehub({ token }).mutation({
+    transaction: {
+      __args: {
+        autoCommit: 'PRO-19: stand up the seven-virtue canon',
+        data: transaction,
+      },
+      status: true,
+      message: true,
+      duration: true,
+    },
+  })
+
+  console.log(`Status: ${result.status} (${result.duration ?? '?'}ms)`)
+  if (result.message) console.log(`Message: ${result.message}`)
+  if (result.status !== 'Completed') process.exit(1)
+  console.log('✓ Done. Run `pnpm basehub` to regenerate types, then switch the')
+  console.log('  read path in src/lib/virtues.ts to prefer Basehub if desired.')
+}
+
+main().catch((err) => {
+  console.error('✗ Transaction failed:', err.message)
+  process.exit(1)
+})

--- a/scripts/seed-virtues.mjs
+++ b/scripts/seed-virtues.mjs
@@ -1,22 +1,34 @@
 // Seed the seven-virtue canon into Basehub (PRO-19).
 //
 // Stands up a `virtues` collection with a component template and one instance
-// per classical virtue (4 cardinal + 3 theological). Idempotent: the collection
-// is keyed on apiName and each row on slug, so re-running updates in place
-// rather than duplicating.
+// per classical virtue (4 cardinal + 3 theological), then commits so the site's
+// read token sees it. Idempotent: the collection is keyed on apiName, and each
+// instance is matched to an existing row by slug and UPDATED in place (the
+// Mutation API's per-instance `idempotency` key auto-suffixes the slug instead
+// of updating, so we resolve ids ourselves and emit update-vs-create ops).
 //
 // The canon itself lives in src/data/virtues.json — the single source of truth
 // shared with the website (src/lib/virtues.ts), so there is no drift.
 //
 // Usage:
-//   BASEHUB_TOKEN must have WRITE scope (an Admin Token). The read token used by
-//   the site at runtime is NOT sufficient. Provide the admin token via the
-//   BASEHUB_ADMIN_TOKEN env var (preferred) or BASEHUB_TOKEN:
+//   BASEHUB_ADMIN_TOKEN must have WRITE scope (an Admin Token). The read token
+//   used by the site at runtime is NOT sufficient. Provide it via env:
 //
-//     BASEHUB_ADMIN_TOKEN=bsh_xxx node --env-file=.env.local scripts/seed-virtues.mjs
+//     BASEHUB_ADMIN_TOKEN=bshb_xxx node --env-file=.env.local scripts/seed-virtues.mjs
 //
-// On success it auto-commits to the Basehub repo and the site's read token will
-// then see the `virtues` collection (run `pnpm basehub` to regenerate types).
+// Why three phases (learned the hard way against the live Mutation API):
+//   1. Create the collection + its template, with NO autoCommit. The API
+//      refuses to autoCommit a transaction that introduces a brand-new
+//      collection, and it will not even stage a collection that carries its
+//      rows inline — so the template must go up on its own first.
+//   2. Create the instances as children of the collection (parentId), again
+//      with NO autoCommit, so they stage cleanly under the staged template.
+//   3. Commit the working tree with an explicit `commit` operation, which is
+//      what actually publishes new collections (autoCommit cannot).
+//
+// NOTE: the `commit` operation publishes the ENTIRE working tree on `main`, not
+// just this script's changes. Run it only when the Basehub working draft holds
+// nothing you are not ready to publish.
 
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
@@ -28,69 +40,133 @@ const VIRTUES = JSON.parse(
   readFileSync(join(__dirname, '..', 'src', 'data', 'virtues.json'), 'utf8'),
 )
 
-function rowFor(v) {
+const TOKEN = process.env.BASEHUB_ADMIN_TOKEN || process.env.BASEHUB_TOKEN
+const API = 'https://api.basehub.com/graphql'
+
+/** Read against the draft (working) tree, where staged-but-uncommitted changes are visible. */
+async function draftQuery(query) {
+  const res = await fetch(API, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-basehub-api-version': '4',
+      'x-basehub-token': TOKEN,
+      'x-basehub-ref': 'main',
+      'x-basehub-draft': 'true',
+    },
+    body: JSON.stringify({ query }),
+  })
+  return res.json()
+}
+
+/** Field values shared by create and update ops. */
+function fieldsFor(v) {
   return {
-    type: 'instance',
-    title: v.title,
-    slug: v.slug,
-    idempotency: { key: 'slug', value: v.slug },
-    value: {
-      order: { type: 'number', value: v.order },
-      tagline: { type: 'text', value: v.tagline },
-      alternateName: { type: 'text', value: v.alternateName ?? '' },
-      description: {
-        type: 'rich-text',
-        value: { format: 'markdown', value: v.description },
-      },
+    order: { type: 'number', value: v.order },
+    tagline: { type: 'text', value: v.tagline },
+    alternateName: { type: 'text', value: v.alternateName ?? '' },
+    description: {
+      type: 'rich-text',
+      value: { format: 'markdown', value: v.description },
     },
   }
 }
 
-const transaction = [
-  {
-    type: 'collection',
-    title: 'Virtues',
-    apiName: 'virtues',
-    description: 'The seven classical virtues — each a home for the stories that teach it.',
-    idempotency: { key: 'apiName', value: 'virtues' },
-    template: [
-      { type: 'number', title: 'Order', apiName: 'order' },
-      { type: 'text', title: 'Tagline', apiName: 'tagline' },
-      { type: 'text', title: 'Alternate Name', apiName: 'alternateName' },
-      { type: 'rich-text', title: 'Description', apiName: 'description' },
-    ],
-    rows: VIRTUES.map(rowFor),
-  },
-]
+/** Update an existing row when we already have its id, otherwise create a child. */
+function instanceOp(collectionId, v, existingId) {
+  if (existingId) {
+    return { type: 'update', id: existingId, value: fieldsFor(v) }
+  }
+  return {
+    type: 'create',
+    parentId: collectionId,
+    data: { type: 'instance', title: v.title, slug: v.slug, value: fieldsFor(v) },
+  }
+}
+
+async function transact(label, data, autoCommit) {
+  const args = { data }
+  if (autoCommit) args.autoCommit = autoCommit
+  const { transaction } = await basehub({ token: TOKEN }).mutation({
+    transaction: { __args: args, status: true, message: true, duration: true },
+  })
+  console.log(`${label}: ${transaction.status}${transaction.message ? ` — ${transaction.message}` : ''}`)
+  if (transaction.status !== 'Completed') {
+    throw new Error(`${label} did not complete (status ${transaction.status})`)
+  }
+}
 
 async function main() {
-  const token = process.env.BASEHUB_ADMIN_TOKEN || process.env.BASEHUB_TOKEN
-  if (!token) {
+  if (!TOKEN) {
     console.error('✗ No token. Set BASEHUB_ADMIN_TOKEN (write scope) and rerun.')
     process.exit(1)
   }
 
-  console.log(`Seeding ${VIRTUES.length} virtues into Basehub…`)
-  const { transaction: result } = await basehub({ token }).mutation({
-    transaction: {
-      __args: {
-        autoCommit: 'PRO-19: stand up the seven-virtue canon',
-        data: transaction,
+  // Phase 1 — collection + template (no commit; new collections cannot autoCommit).
+  await transact('1/3 collection template', [
+    {
+      type: 'create',
+      data: {
+        type: 'collection',
+        title: 'Virtues',
+        apiName: 'virtues',
+        description:
+          'The seven classical virtues — each a home for the stories that teach it.',
+        idempotency: { key: 'apiName', value: 'virtues' },
+        template: [
+          { type: 'number', title: 'Order', apiName: 'order' },
+          { type: 'text', title: 'Tagline', apiName: 'tagline' },
+          { type: 'text', title: 'Alternate Name', apiName: 'alternateName' },
+          { type: 'rich-text', title: 'Description', apiName: 'description' },
+        ],
       },
-      status: true,
-      message: true,
-      duration: true,
     },
-  })
+  ])
 
-  console.log(`Status: ${result.status} (${result.duration ?? '?'}ms)`)
-  if (result.message) console.log(`Message: ${result.message}`)
-  if (result.status !== 'Completed') process.exit(1)
-  console.log('✓ Done. Run `pnpm basehub` to regenerate types, then switch the')
-  console.log('  read path in src/lib/virtues.ts to prefer Basehub if desired.')
+  // Resolve the (possibly just-staged) collection id and any existing rows from
+  // the draft tree, so we update rows in place instead of duplicating them.
+  const idResult = await draftQuery(
+    'query { virtues { _id items { _id _slug } } }',
+  )
+  const collectionId = idResult?.data?.virtues?._id
+  if (!collectionId) {
+    throw new Error(`Could not resolve virtues collection id: ${JSON.stringify(idResult?.errors ?? idResult)}`)
+  }
+  const idBySlug = new Map(
+    (idResult?.data?.virtues?.items ?? []).map((i) => [i._slug, i._id]),
+  )
+  console.log(`    virtues collection id: ${collectionId} (${idBySlug.size} existing rows)`)
+
+  // Phase 2 — upsert instances as children (no commit; stage under the template).
+  await transact(
+    `2/3 ${VIRTUES.length} virtue instances`,
+    VIRTUES.map((v) => instanceOp(collectionId, v, idBySlug.get(v.slug))),
+  )
+
+  // Phase 3 — publish the working tree.
+  await transact('3/3 commit', [
+    { type: 'commit', branchName: 'main', message: 'PRO-19: stand up the seven-virtue canon' },
+  ])
+
+  // Verify against the published (non-draft) tree.
+  const check = await fetch(API, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-basehub-api-version': '4',
+      'x-basehub-token': TOKEN,
+      'x-basehub-ref': 'main',
+    },
+    body: JSON.stringify({ query: 'query { virtues { items { _title _slug } } }' }),
+  }).then((r) => r.json())
+  const items = check?.data?.virtues?.items ?? []
+  console.log(`✓ Published ${items.length} virtues: ${items.map((i) => i._slug).join(', ')}`)
+  if (items.length !== VIRTUES.length) {
+    throw new Error(`Expected ${VIRTUES.length} virtues published, found ${items.length}`)
+  }
 }
 
 main().catch((err) => {
-  console.error('✗ Transaction failed:', err.message)
+  console.error('✗ Seed failed:', err.message)
   process.exit(1)
 })

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,5 +1,6 @@
 import type { MetadataRoute } from 'next'
 import { getAllStories } from '@/lib/stories'
+import { getVirtueSlugs } from '@/lib/virtues'
 
 const BASE_URL = 'https://classicalvirtues.com'
 
@@ -18,10 +19,20 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.9,
     },
     {
+      url: `${BASE_URL}/virtues`,
+      changeFrequency: 'weekly',
+      priority: 0.9,
+    },
+    {
       url: `${BASE_URL}/about`,
       changeFrequency: 'monthly',
       priority: 0.5,
     },
+    ...getVirtueSlugs().map((slug) => ({
+      url: `${BASE_URL}/virtues/${slug}`,
+      changeFrequency: 'monthly' as const,
+      priority: 0.7,
+    })),
     ...stories.map((story) => ({
       url: `${BASE_URL}/stories/${story.slug}`,
       changeFrequency: 'monthly' as const,

--- a/src/app/virtues/[slug]/page.tsx
+++ b/src/app/virtues/[slug]/page.tsx
@@ -1,0 +1,138 @@
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import SummaryCard from '@/components/summaryCard'
+import JsonLd from '@/components/JsonLd'
+import { getVirtueBySlug, getVirtueSlugs } from '@/lib/virtues'
+import type { Metadata } from 'next'
+
+type Params = Promise<{ slug: string }>
+
+export function generateStaticParams() {
+  return getVirtueSlugs().map((slug) => ({ slug }))
+}
+
+export async function generateMetadata({ params }: { params: Params }): Promise<Metadata> {
+  const { slug } = await params
+  const virtue = await getVirtueBySlug(slug)
+
+  if (!virtue) {
+    return {
+      title: 'Virtue Not Found',
+      description: 'The requested virtue could not be found.',
+    }
+  }
+
+  const ogImage = `/api/og?title=${encodeURIComponent(virtue.title)}&virtue=${encodeURIComponent(virtue.tagline)}`
+
+  return {
+    title: virtue.title,
+    description: virtue.tagline,
+    alternates: {
+      canonical: `/virtues/${slug}`,
+    },
+    keywords: [virtue.title, virtue.alternateName, 'virtue', 'classical virtues'].filter(
+      (k): k is string => Boolean(k),
+    ),
+    openGraph: {
+      type: 'website',
+      url: `https://classicalvirtues.com/virtues/${slug}`,
+      title: virtue.title,
+      description: virtue.tagline,
+      images: [{ url: ogImage, width: 1200, height: 630, alt: virtue.title }],
+      siteName: 'Classical Virtues',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: virtue.title,
+      description: virtue.tagline,
+      images: [ogImage],
+    },
+  }
+}
+
+export default async function VirtuePage({ params }: { params: Params }) {
+  const { slug } = await params
+  const virtue = await getVirtueBySlug(slug)
+
+  if (!virtue) {
+    notFound()
+  }
+
+  const breadcrumbSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://classicalvirtues.com' },
+      { '@type': 'ListItem', position: 2, name: 'Virtues', item: 'https://classicalvirtues.com/virtues' },
+      {
+        '@type': 'ListItem',
+        position: 3,
+        name: virtue.title,
+        item: `https://classicalvirtues.com/virtues/${slug}`,
+      },
+    ],
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
+      <nav aria-label="Breadcrumb" className="mb-6 text-sm text-muted-foreground">
+        <Link href="/">Home</Link>
+        <span className="mx-2" aria-hidden="true">/</span>
+        <Link href="/virtues">Virtues</Link>
+        <span className="mx-2" aria-hidden="true">/</span>
+        <span aria-current="page">{virtue.title}</span>
+      </nav>
+
+      <header className="mb-8 space-y-3">
+        <div className="flex flex-wrap items-baseline gap-x-3">
+          <h1 className="font-heading text-4xl tracking-wide sm:text-5xl">{virtue.title}</h1>
+          {virtue.alternateName && (
+            <span className="font-heading text-2xl italic text-muted-foreground">
+              {virtue.alternateName}
+            </span>
+          )}
+        </div>
+        <p className="font-heading text-xl italic text-primary">{virtue.tagline}</p>
+      </header>
+
+      <div className="prose prose-lg max-w-none">
+        <p className="leading-relaxed">{virtue.description}</p>
+      </div>
+
+      <section aria-labelledby="virtue-stories" className="mt-12 border-t border-border pt-8">
+        <h2 id="virtue-stories" className="font-heading text-2xl">
+          Stories of {virtue.title.toLowerCase()}
+        </h2>
+        {virtue.stories.length === 0 ? (
+          <p className="mt-4 text-muted-foreground">
+            No stories have been gathered here yet — they are being prepared.{' '}
+            <Link href="/stories" className="underline underline-offset-4 hover:text-foreground">
+              Browse the whole collection
+            </Link>
+            .
+          </p>
+        ) : (
+          <ol role="list" className="mt-2 list-none border-t border-border p-0">
+            {virtue.stories.map((story, index) => (
+              <li key={story.id}>
+                <SummaryCard
+                  variant="index"
+                  position={index + 1}
+                  slug={story.slug}
+                  image={story.image}
+                  title={story.title}
+                  summary={story.summary}
+                  virtue={story.virtue}
+                  audioUrl={story.audioUrl}
+                  wordCount={story.wordCount}
+                />
+              </li>
+            ))}
+          </ol>
+        )}
+      </section>
+
+      <JsonLd data={breadcrumbSchema} />
+    </div>
+  )
+}

--- a/src/app/virtues/page.tsx
+++ b/src/app/virtues/page.tsx
@@ -1,0 +1,75 @@
+import Link from 'next/link'
+import JsonLd from '@/components/JsonLd'
+import { getAllVirtues } from '@/lib/virtues'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'The Virtues',
+  description:
+    'The seven classical virtues — Prudence, Justice, Fortitude, Temperance, Faith, Hope, and Charity — each a home for the stories that teach it.',
+  alternates: {
+    canonical: '/virtues',
+  },
+}
+
+export default async function VirtuesIndex() {
+  const virtues = await getAllVirtues()
+
+  const itemListSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    name: 'The Seven Classical Virtues',
+    itemListElement: virtues.map((virtue, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: virtue.title,
+      url: `https://classicalvirtues.com/virtues/${virtue.slug}`,
+    })),
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-10 sm:px-6 sm:py-14 lg:px-8">
+      <header className="mb-8 space-y-3 sm:mb-10">
+        <h1 className="font-heading text-4xl sm:text-5xl">The Virtues</h1>
+        <p className="max-w-2xl text-muted-foreground">
+          The seven classical virtues that order this collection — four cardinal
+          and three theological. Each one gathers the stories that teach it.
+        </p>
+      </header>
+
+      <ol role="list" className="list-none border-t border-border p-0">
+        {virtues.map((virtue) => (
+          <li key={virtue.slug}>
+            <Link
+              href={`/virtues/${virtue.slug}`}
+              className="group flex flex-col gap-1.5 border-b border-border py-6 transition-colors duration-200 hover:border-foreground sm:py-7"
+            >
+              <div className="flex flex-wrap items-baseline gap-x-3">
+                <h2 className="font-heading text-2xl leading-snug underline-offset-4 decoration-1 group-hover:underline sm:text-3xl">
+                  {virtue.title}
+                </h2>
+                {virtue.alternateName && (
+                  <span className="font-heading text-lg italic text-muted-foreground">
+                    {virtue.alternateName}
+                  </span>
+                )}
+              </div>
+              <p className="font-heading text-lg italic text-primary">
+                {virtue.tagline}
+              </p>
+              <p className="text-sm text-muted-foreground">
+                {virtue.stories.length === 0
+                  ? 'Stories coming soon'
+                  : `${virtue.stories.length} ${
+                      virtue.stories.length === 1 ? 'story' : 'stories'
+                    }`}
+              </p>
+            </Link>
+          </li>
+        ))}
+      </ol>
+
+      <JsonLd data={itemListSchema} />
+    </div>
+  )
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -5,6 +5,7 @@ import { usePathname } from 'next/navigation';
 
 const links = [
   { href: '/stories', label: 'Stories' },
+  { href: '/virtues', label: 'Virtues' },
   { href: '/about', label: 'About' },
 ];
 

--- a/src/data/virtues.json
+++ b/src/data/virtues.json
@@ -1,0 +1,53 @@
+[
+  {
+    "slug": "prudence",
+    "title": "Prudence",
+    "order": 1,
+    "tagline": "The wisdom to choose well.",
+    "description": "Prudence is the quiet art of seeing clearly before we act — weighing what is true, what is kind, and what is wise, then choosing the better path. It is the virtue that quietly guides all the others, the steady voice that asks, “What is the right thing to do, and how shall I do it well?” In these stories, prudence looks like patience, good judgment, and the courage to think before we leap."
+  },
+  {
+    "slug": "justice",
+    "title": "Justice",
+    "order": 2,
+    "tagline": "Giving each their due.",
+    "description": "Justice is the habit of treating others fairly and giving each person what they are owed — honesty, respect, and a fair share. It asks us to keep our promises, to make right what we have wronged, and to stand up for those who cannot stand for themselves. The stories gathered here show justice as something warm and human: the keeping of one’s word, the mending of a quarrel, the small acts of fairness that hold a family together."
+  },
+  {
+    "slug": "fortitude",
+    "title": "Fortitude",
+    "alternateName": "Courage",
+    "order": 3,
+    "tagline": "Standing firm when it is hard.",
+    "description": "Fortitude — the virtue we more often call courage — is the strength to do what is right even when it is difficult or frightening. It is not the absence of fear but the steadiness to act in spite of it: to endure hardship, to face danger for a good cause, and to hold fast to what is true. In these tales courage wears many faces, the bold and the quiet alike, but always it means standing firm when standing firm is hard."
+  },
+  {
+    "slug": "temperance",
+    "title": "Temperance",
+    "order": 4,
+    "tagline": "Moderation and gentle self-mastery.",
+    "description": "Temperance is the gift of self-mastery — knowing when enough is enough, and choosing balance over excess. It teaches us to govern our appetites and our tempers, to enjoy good things without being ruled by them, and to find the calm that comes from a well-ordered heart. The stories here show temperance as a quiet kind of freedom: the patience to wait, the grace to share, and the wisdom to keep ourselves in gentle check."
+  },
+  {
+    "slug": "faith",
+    "title": "Faith",
+    "order": 5,
+    "tagline": "Trust that holds fast.",
+    "description": "Faith is trust — in what is good, in one another, and in the promises we hold dear. It is the quiet confidence that carries us through uncertainty, the belief that keeps us steadfast when we cannot yet see the way. In these stories faith appears as loyalty kept, trust honored, and hearts that hold fast to hope even in the dark."
+  },
+  {
+    "slug": "hope",
+    "title": "Hope",
+    "order": 6,
+    "tagline": "Looking forward in good cheer.",
+    "description": "Hope is the bright expectation that good things lie ahead, and the courage to keep going until we reach them. It lifts our eyes past present troubles toward what may yet be, and it gives us patience to wait and strength to persevere. The tales gathered under hope remind us that even the longest night gives way to morning, and that to hope is itself a kind of quiet bravery."
+  },
+  {
+    "slug": "charity",
+    "title": "Charity",
+    "alternateName": "Love",
+    "order": 7,
+    "tagline": "Love that gives without counting the cost.",
+    "description": "Charity — the love that gives freely — is the greatest of the virtues and the warm heart of all the rest. It is kindness without keeping score, compassion for the stranger, and the willingness to put another’s good before our own. In these stories charity looks like an open hand and an open door: mercy shown, burdens shared, and love offered without counting the cost."
+  }
+]

--- a/src/lib/virtues.ts
+++ b/src/lib/virtues.ts
@@ -1,0 +1,65 @@
+import virtuesData from '@/data/virtues.json'
+import { getAllStories, type StoryData } from './stories'
+
+/**
+ * The seven classical virtues — the fixed canon (four cardinal, three
+ * theological). The descriptions are warm, family-anthology copy.
+ *
+ * This is the source of truth for the canon and is mirrored into Basehub by
+ * `scripts/seed-virtues.mjs`. Because the canon never changes, it lives in the
+ * repo so the site renders all seven regardless of CMS availability — the same
+ * graceful-degradation principle used for stories in `src/lib/stories.ts`.
+ */
+export interface Virtue {
+  slug: string
+  title: string
+  /** A familiar alternate name, e.g. Courage for Fortitude, Love for Charity. */
+  alternateName?: string
+  order: number
+  tagline: string
+  description: string
+}
+
+export interface VirtueData extends Virtue {
+  /** Stories from Basehub whose `virtue` matches this virtue's name. */
+  stories: StoryData[]
+}
+
+const VIRTUES: Virtue[] = (virtuesData as Virtue[])
+  .slice()
+  .sort((a, b) => a.order - b.order)
+
+/** True when a story's free-text virtue matches this virtue's name or alias. */
+function storyMatchesVirtue(virtue: Virtue, storyVirtue: string): boolean {
+  const needle = storyVirtue.trim().toLowerCase()
+  return (
+    needle === virtue.title.toLowerCase() ||
+    needle === virtue.alternateName?.toLowerCase()
+  )
+}
+
+/** All seven virtues, in canonical order, each with its attached stories. */
+export async function getAllVirtues(): Promise<VirtueData[]> {
+  const stories = await getAllStories()
+  return VIRTUES.map((virtue) => ({
+    ...virtue,
+    stories: stories.filter((s) => storyMatchesVirtue(virtue, s.virtue)),
+  }))
+}
+
+/** A single virtue by slug, with its attached stories, or null if unknown. */
+export async function getVirtueBySlug(slug: string): Promise<VirtueData | null> {
+  const virtue = VIRTUES.find((v) => v.slug === slug)
+  if (!virtue) return null
+
+  const stories = await getAllStories()
+  return {
+    ...virtue,
+    stories: stories.filter((s) => storyMatchesVirtue(virtue, s.virtue)),
+  }
+}
+
+/** Slugs for static generation, no CMS round-trip needed. */
+export function getVirtueSlugs(): string[] {
+  return VIRTUES.map((v) => v.slug)
+}


### PR DESCRIPTION
## PRO-19 — Stand up the seven-virtue canon

Stands up the classical seven-virtue canon (4 cardinal + 3 theological) and renders it on the site, so stories have a home.

### What's here
- **Canon as source of truth:** `src/data/virtues.json` holds all seven (Prudence, Justice, Fortitude/Courage, Temperance, Faith, Hope, Charity/Love) with `order`, `tagline`, `alternateName`, and a warm family-anthology description each.
- **Site rendering:** `/virtues` index + `/virtues/[slug]` pages (`src/app/virtues/…`), `src/lib/virtues.ts` accessor, Navbar link, sitemap entries. Renders all seven from the repo canon regardless of CMS availability (graceful degradation, same pattern as stories).
- **Basehub:** `scripts/seed-virtues.mjs` mirrors the canon into a Basehub `virtues` collection. **Already run against the live repo** — the read token now returns all 7. The script is idempotent (query-then-upsert), so re-running updates in place. `basehub-types.d.ts` regenerated to include the collection.

### Verification
- `pnpm build` succeeds; `/virtues` and `/virtues/[slug]` routes present and render.
- Basehub read token returns exactly 7 virtues in canonical order.

### Notes
- Authoring the stories themselves is out of scope (next issue). Each virtue page renders with no story attached yet.
- Mutation API learnings (whole-working-tree commit, idempotency quirks) are documented in `scripts/seed-virtues.mjs`. While wrangling commit semantics I inadvertently published a pre-existing dashboard draft (`About.subtitle = "About 2"`); the site does not query `subtitle`, so no user-facing effect — flagged on the issue for the content owner.

Unblocks PRO-33 (pilot publish) once deployed.

Co-Authored-By: Paperclip <noreply@paperclip.ing>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
