### PR TITLE
PRO-55: render CMS imageAlt + link story eyebrow to virtue hub

### DIFF
--- a/src/app/stories/[slug]/page.tsx
+++ b/src/app/stories/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { getAllStories, getStoryBySlug } from '@/lib/stories';
+import { getVirtueSlugForStoryVirtue } from '@/lib/virtues';
 import { compileMDX } from 'next-mdx-remote/rsc';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -104,6 +105,7 @@ export default async function Post({ params }: { params: Params }) {
   ].slice(0, 3);
 
   const minutes = Math.max(1, Math.round(story.wordCount / 140));
+  const virtueSlug = getVirtueSlugForStoryVirtue(story.virtue);
   const storyContent = await renderStoryContent(story.content);
 
   const articleStructuredData = {
@@ -151,13 +153,24 @@ export default async function Post({ params }: { params: Params }) {
       <header className="mb-8">
         <h1 className="text-4xl sm:text-5xl font-heading tracking-wide">{story.title}</h1>
         <p className="mt-3 text-muted-foreground">
-          A story of {story.virtue.toLowerCase()} · About {minutes} {minutes === 1 ? 'minute' : 'minutes'}
+          A story of{' '}
+          {virtueSlug ? (
+            <Link
+              href={`/virtues/${virtueSlug}`}
+              className="underline underline-offset-4 hover:text-foreground"
+            >
+              {story.virtue.toLowerCase()}
+            </Link>
+          ) : (
+            story.virtue.toLowerCase()
+          )}{' '}
+          · About {minutes} {minutes === 1 ? 'minute' : 'minutes'}
         </p>
       </header>
       <div className="relative w-full h-80 mb-8 overflow-hidden">
         <Image
           src={story.image}
-          alt={`Illustration for ${story.title}`}
+          alt={story.imageAlt || `Illustration for ${story.title}`}
           fill
           priority
           sizes="(max-width: 768px) 100vw, 768px"

--- a/src/lib/stories.ts
+++ b/src/lib/stories.ts
@@ -7,6 +7,8 @@ export interface StoryData {
   title: string
   virtue: string
   image: string
+  /** Concrete, descriptive alt text for the story image (from the CMS). */
+  imageAlt: string
   summary: string
   content: string
   virtueDescription: string
@@ -21,7 +23,7 @@ function basehubToStory(story: Story): StoryData | null {
     console.warn(`Story "${story._title}" has no content`)
     return null
   }
-  
+
   return {
     id: story._id,
     slug: story._slug,
@@ -29,6 +31,7 @@ function basehubToStory(story: Story): StoryData | null {
     title: story._title,
     virtue: story.virtue,
     image: story.image.url,
+    imageAlt: story.image.alt || '',
     summary: story.summary,
     content: story.content.markdown,
     virtueDescription: story.virtueDescription,
@@ -73,4 +76,4 @@ export async function getStoryBySlug(slug: string): Promise<StoryData | null> {
     console.error('❌ Failed to fetch story from Basehub:', error)
     return null
   }
-} 
+}

--- a/src/lib/virtues.ts
+++ b/src/lib/virtues.ts
@@ -63,3 +63,12 @@ export async function getVirtueBySlug(slug: string): Promise<VirtueData | null> 
 export function getVirtueSlugs(): string[] {
   return VIRTUES.map((v) => v.slug)
 }
+
+/**
+ * Resolve a story's free-text virtue to its canonical virtue-hub slug, or null
+ * when it maps to no canon entry. Lets a story link back up to its virtue page
+ * using the same name/alias matching the virtue pages use to gather stories.
+ */
+export function getVirtueSlugForStoryVirtue(storyVirtue: string): string | null {
+  return VIRTUES.find((v) => storyMatchesVirtue(v, storyVirtue))?.slug ?? null
+}


### PR DESCRIPTION
## What & why

Implements the two quick-win SEO/a11y improvements from PRO-55 (surfaced during PRO-54 SEO QA). Non-blocking, catalog-wide discoverability wins. All changes are outside story `content` — rendering/schema only, preserving the anthology-first reading experience per `@writing.md`.

### 1. Render `imageAlt` for story images
The story page hard-coded `alt="Illustration for {title}"` and dropped the CMS-provided alt text. The Basehub `image.alt` field is already fetched but was discarded in `basehubToStory`. Now surfaced via `StoryData.imageAlt` and used for the illustration's `alt`, falling back to the prior generic value when empty. (Image-SEO + WCAG 2.1 AA.)

### 2. Story → virtue-hub internal link
The "A story of {virtue}" eyebrow was plain text. Added `getVirtueSlugForStoryVirtue()` (reuses the existing name/alias matching virtue pages use to gather stories) and made the eyebrow link to `/virtues/{slug}`, completing hub-and-spoke link equity. Falls back to plain text when the virtue maps to no canon entry.

### 3. `metaTitle` / `metaDescription` — deferred
Not in the Basehub `StoriesItem` schema and no current demand per the issue. Left for a future schema change (editorial owner: Margaret).

## Verification
- `tsc --noEmit` — clean
- `eslint .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)