### PR TITLE
PRO-56: Writing Vault, SEO contract & hardening, catalog consistency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,10 @@ affects the public reading experience:
   seven-virtue canon.
 - `@writing.md` — prose voice, approved story structure, field contract, canon
   mapping, and SEO boundaries.
+- `content/vault/new-virtue-checklist.md` — turnkey steps for adding a story so
+  it lands on the right canon hub and conforms to the field contract. Adding a
+  new sub-virtue angle requires one line in `SUB_VIRTUE_TO_CANON_SLUG`
+  (`src/lib/virtues.ts`); see also `content/vault/catalog-audit.md`.
 
 Engineering work must preserve approved editorial content unless the task
 explicitly asks for editorial changes. Do not rewrite story prose, titles,

--- a/SEO.md
+++ b/SEO.md
@@ -1,0 +1,66 @@
+# SEO Contract
+
+Standing rule for Classical Virtues. Derived from the **SEO Boundary** in
+`@writing.md`; read this with `@writing.md` and `@PRODUCT.md`. This contract is
+binding on Quinn (SEO), Margaret (Managing Editor), and Quill (writer), and on
+any engineering work that touches story rendering, metadata, or structured data.
+
+## Principle
+
+SEO serves discoverability. It does not control the reading experience. The
+public reading experience is anthology-first: a story must never read like an
+SEO article. When ranking advice conflicts with story quality, the metadata /
+structured-data path wins and Margaret decides the final editorial treatment.
+
+## Allowed SEO surfaces
+
+Search optimization lives **outside the story body**, in these surfaces only:
+
+- **Slug** — short, lowercase, hyphenated, keyword-bearing, stable. Never change
+  a live slug without a redirect plan (escalate to engineering).
+- **Metadata title** — rendered from the story `title` via the
+  `%s | Classical Virtues` template. Keep titles anthology-clean, not SEO
+  subtitles.
+- **Meta description** — rendered from the story `summary`. This is the only
+  reader-facing copy that doubles as the search snippet.
+- **Summary** — short reader-facing summary used for cards and metadata.
+- **Structured data (JSON-LD)** — Article, BreadcrumbList, ItemList, WebSite,
+  Organization, AudioObject. Keywords, author, and publisher signals live here.
+- **OpenGraph / Twitter cards + OG image** — title, description, and the
+  generated `/api/og` image.
+- **Internal-link recommendations** — proposed outside the story body (related
+  navigation is supplied by the site template, not written into the prose).
+- **Brief notes** — search intent, target terms, and link maps for the editor
+  and writer.
+
+## Forbidden in the story body
+
+The `content` field is **narrative only**. None of the following may appear
+inside a story body:
+
+- headings like `What is the moral of...`;
+- FAQ / "people also ask" / snippet copy that interrupts the tale;
+- forced phrases such as `story for kids` or `read aloud to your kids`;
+- keyword-stuffed first paragraphs or keyword lists;
+- related-reading / "you may also like" blocks;
+- a duplicate moral heading (the moral lives once, in `virtueDescription`,
+  rendered as the "The Moral of the Story" card);
+- title subtitles added only for search.
+
+## Roles
+
+- **Quinn** recommends target terms, search intent, slugs, metadata copy, and
+  internal-link maps; runs pre-publish SEO QA against this contract.
+- **Margaret** decides how that guidance enters published content and owns the
+  final editorial treatment.
+- **Quill** keeps the story voice intact and the body free of SEO scaffolding.
+- **Engineering** owns how metadata and structured data are implemented; Quinn
+  specifies the SEO outcome, not the code.
+
+## Pre-publish check (SEO half)
+
+Before a story ships, confirm: slug is clean and stable; metadata title is
+anthology-clean; meta description / summary reads naturally and fits the snippet;
+structured data is present and correct; image alt text is meaningful; internal
+links are recommended outside the body; and **the story body contains zero SEO
+scaffolding** from the forbidden list above.

--- a/basehub-types.d.ts
+++ b/basehub-types.d.ts
@@ -373,13 +373,14 @@ export interface StoriesItem {
     audioUrl: (Scalars['String'] | null)
     content: (Content_1 | null)
     image: BlockImage
+    source: (Scalars['String'] | null)
     summary: Scalars['String']
     virtue: Scalars['String']
     virtueDescription: Scalars['String']
     __typename: 'StoriesItem'
 }
 
-export type StoriesItemOrderByEnum = '_sys_createdAt__ASC' | '_sys_createdAt__DESC' | '_sys_hash__ASC' | '_sys_hash__DESC' | '_sys_id__ASC' | '_sys_id__DESC' | '_sys_lastModifiedAt__ASC' | '_sys_lastModifiedAt__DESC' | '_sys_slug__ASC' | '_sys_slug__DESC' | '_sys_title__ASC' | '_sys_title__DESC' | 'audioUrl__ASC' | 'audioUrl__DESC' | 'content__ASC' | 'content__DESC' | 'image__ASC' | 'image__DESC' | 'summary__ASC' | 'summary__DESC' | 'virtueDescription__ASC' | 'virtueDescription__DESC' | 'virtue__ASC' | 'virtue__DESC'
+export type StoriesItemOrderByEnum = '_sys_createdAt__ASC' | '_sys_createdAt__DESC' | '_sys_hash__ASC' | '_sys_hash__DESC' | '_sys_id__ASC' | '_sys_id__DESC' | '_sys_lastModifiedAt__ASC' | '_sys_lastModifiedAt__DESC' | '_sys_slug__ASC' | '_sys_slug__DESC' | '_sys_title__ASC' | '_sys_title__DESC' | 'audioUrl__ASC' | 'audioUrl__DESC' | 'content__ASC' | 'content__DESC' | 'image__ASC' | 'image__DESC' | 'source__ASC' | 'source__DESC' | 'summary__ASC' | 'summary__DESC' | 'virtueDescription__ASC' | 'virtueDescription__DESC' | 'virtue__ASC' | 'virtue__DESC'
 
 export interface TransactionStatus {
     /** Duration in milliseconds. */
@@ -1135,6 +1136,7 @@ export interface StoriesItemGenqlSelection{
     audioUrl?: boolean | number
     content?: Content_1GenqlSelection
     image?: BlockImageGenqlSelection
+    source?: boolean | number
     summary?: boolean | number
     virtue?: boolean | number
     virtueDescription?: boolean | number
@@ -1142,7 +1144,7 @@ export interface StoriesItemGenqlSelection{
     __fragmentOn?: "StoriesItem"
 }
 
-export interface StoriesItemFilterInput {AND?: (StoriesItemFilterInput | null),OR?: (StoriesItemFilterInput | null),_id?: (StringFilter | null),_slug?: (StringFilter | null),_sys_apiNamePath?: (StringFilter | null),_sys_createdAt?: (DateFilter | null),_sys_hash?: (StringFilter | null),_sys_id?: (StringFilter | null),_sys_idPath?: (StringFilter | null),_sys_lastModifiedAt?: (DateFilter | null),_sys_slug?: (StringFilter | null),_sys_slugPath?: (StringFilter | null),_sys_title?: (StringFilter | null),_title?: (StringFilter | null),audioUrl?: (StringFilter | null),summary?: (StringFilter | null),virtue?: (StringFilter | null),virtueDescription?: (StringFilter | null)}
+export interface StoriesItemFilterInput {AND?: (StoriesItemFilterInput | null),OR?: (StoriesItemFilterInput | null),_id?: (StringFilter | null),_slug?: (StringFilter | null),_sys_apiNamePath?: (StringFilter | null),_sys_createdAt?: (DateFilter | null),_sys_hash?: (StringFilter | null),_sys_id?: (StringFilter | null),_sys_idPath?: (StringFilter | null),_sys_lastModifiedAt?: (DateFilter | null),_sys_slug?: (StringFilter | null),_sys_slugPath?: (StringFilter | null),_sys_title?: (StringFilter | null),_title?: (StringFilter | null),audioUrl?: (StringFilter | null),source?: (StringFilter | null),summary?: (StringFilter | null),virtue?: (StringFilter | null),virtueDescription?: (StringFilter | null)}
 
 export interface StoriesItemSearchInput {
 /** Searchable fields for query */

--- a/content/production-recipe.md
+++ b/content/production-recipe.md
@@ -1,0 +1,126 @@
+# Classical Virtues Production Recipe
+
+This recipe governs normal story production from idea to Basehub publish. It is
+human-triggered at every handoff. Do not build an automatic self-feeding content
+loop from these steps.
+
+## 1. Brief
+
+Owner: Margaret, with SEO input from Quinn when search demand is part of the
+assignment.
+
+The brief must include:
+
+- plain anthology title or working title;
+- source/provenance note and any uncertainty to verify or cut;
+- canonical virtue from the seven-virtue canon;
+- optional sub-virtue angle and the reason it maps to the canon;
+- intended reader/search fit;
+- target length, defaulting to 350-650 words unless the brief explains why a
+  longer treatment is needed;
+- required structured fields: `slug`, `summary`, `virtueDescription`,
+  `source`, `imageAlt`, and audio expectation;
+- SEO guidance limited to metadata, summary, slug, structured discoverability,
+  image alt text, and internal-link recommendations.
+
+The brief is not ready for drafting if it asks for body-level SEO blocks,
+unclear canon labels, invented quotations, or source claims that cannot be
+verified.
+
+## 2. Draft
+
+Owner: Quill.
+
+The draft must follow `writing.md`:
+
+- paragraph one establishes actor, setting, and moral pressure;
+- the story body is narrative only;
+- virtue is shown before it is named;
+- ornamental modifiers are cut back to concrete details;
+- sentence rhythm works aloud for a parent reading at bedtime;
+- the ending trusts the earned action or image, with explicit reflection reserved
+  for `virtueDescription`.
+
+Quill should return the draft with all required structured fields and any source
+or canon questions called out for Margaret.
+
+## 3. Editorial Gate Against Vault Exemplars
+
+Owner: Margaret.
+
+Before a draft can move toward publish, Margaret compares it against at least
+two locked exemplars in `content/vault/exemplars/` and records the comparison in
+the task thread or publish notes.
+
+The comparison must name the two exemplars and check:
+
+- opening pressure: actor, setting, and moral test appear promptly;
+- virtue order: action before naming;
+- rhythm: plain read-aloud sequence, not grand motivational cadence;
+- diction: concrete nouns and verbs carry the prose;
+- ending: no second moral ending inside `content`;
+- field contract: `content` narrative only, `virtueDescription` reflection once,
+  accurate source note, meaningful image alt text;
+- canon: one canonical virtue, with any sub-virtue kept as an angle.
+
+Verdict options:
+
+- `publish`: all gates pass and SEO QA is cleared;
+- `revise-with-notes`: the story can meet the bar with specific changes;
+- `kill`: the premise, source, or voice cannot be made trustworthy without
+  starting over.
+
+## 4. SEO QA
+
+Owner: Quinn.
+
+Quinn checks discoverability surfaces only:
+
+- slug;
+- metadata title and description;
+- summary/search fit;
+- structured data fit;
+- image alt text;
+- internal-link recommendations outside the story body.
+
+SEO QA fails if the story body contains keyword-stuffed openings, FAQ blocks,
+`What is the moral of...` headings, `story for kids` phrasing, or related-story
+paragraphs embedded in the narrative.
+
+## 5. Basehub Publish
+
+Owner: Margaret.
+
+Publish only after:
+
+- Margaret's editorial verdict is `publish`;
+- Quinn's SEO QA is clear;
+- source/provenance uncertainty is resolved or cut;
+- required fields are present;
+- no body-level SEO scaffolding remains.
+
+After publishing in Basehub, verify the rendered story page:
+
+- story URL resolves;
+- title, summary, virtue, story body, moral/reflection, image alt text, and audio
+  state match the approved fields;
+- no duplicate moral card, separator, FAQ, or related-reading block appears in
+  the body;
+- there is a clear next-story or related-story path supplied by the site;
+- metadata and structured discoverability use the approved summary and slug.
+
+The final task comment must include the rendered URL, Basehub/publish evidence,
+SEO QA result, vault exemplars used, and any follow-up owner.
+
+## 6. Engineering Escalation
+
+If approved content cannot render or publish safely, Margaret stops the publish
+and routes a task to Engineering with:
+
+- the story or field affected;
+- the reader-facing impact;
+- the expected behavior from `writing.md` and this recipe;
+- any repro steps or rendered URL.
+
+Do not patch code, schema, scripts, deployment, adapter config, or secrets from
+the editorial workflow.

--- a/content/vault/README.md
+++ b/content/vault/README.md
@@ -1,0 +1,29 @@
+# Classical Virtues Writing Vault
+
+Purpose: this vault locks the three original Basehub stories as the tone reference for future Classical Virtues drafting and review.
+
+The exemplars are not a replacement for `PRODUCT.md` or `writing.md`. They are the prose bench: what a story should feel like when read aloud by a parent at bedtime.
+
+## Locked Exemplars
+
+- `exemplars/androcles-and-the-lion.md`
+- `exemplars/david-and-mephibosheth.md`
+- `exemplars/the-cherry-tree.md`
+
+Each exemplar preserves the Basehub-exported story fields and exact body text, then adds editorial notes outside the `## Locked Story Body` section. Do not edit the locked body to improve diction, canon labels, SEO, or metadata. If Basehub content changes intentionally, add a new dated export note rather than silently rewriting the reference.
+
+## How To Use This Vault
+
+Use the exemplars to check:
+
+- whether the story opens on a concrete person in a concrete circumstance;
+- whether virtue is shown by action before it is named;
+- whether sentences are plain enough for read-aloud delivery;
+- whether the moral lands once, after the narrative has earned it;
+- whether SEO language stays out of the story body.
+
+Important canon note: these originals are locked as tone exemplars. Their legacy `virtue` labels include sub-virtues (`Kindness`, `Mercy`, `Honesty`) that now need mapping back to the seven-virtue canon before publication work. Do not copy those labels into new briefs without a canonical mapping.
+
+## Drift Diagnosis
+
+See `drift-diagnosis.md` for the current comparison against recent stories. That diagnosis is the input for A2 writing-guide hardening.

--- a/content/vault/catalog-audit.md
+++ b/content/vault/catalog-audit.md
@@ -1,0 +1,86 @@
+# Catalog Consistency Audit
+
+Workstream C1 ([PRO-61]). Audited on 2026-06-20 against the field contract in
+`writing.md` and the seven-virtue canon in `PRODUCT.md`.
+
+Catalog source: live production (`https://www.classicalvirtues.com/sitemap.xml`)
+plus the locked Basehub exports in `exemplars/`. Seven stories are published.
+
+## Field Contract Conformance
+
+Contract fields (per `writing.md`): `title`, `slug`, `summary`, `content`,
+`virtueDescription`, `virtue`, `canonicalVirtue`, `source`, `imageAlt`,
+`audioUrl` (optional).
+
+| Story (slug) | Stored `virtue` | Canon virtue | summary | imageAlt | source | audio |
+| --- | --- | --- | --- | --- | --- | --- |
+| `androcles-and-the-lion` | Kindness | **Charity** | ✓ | ✗ empty | — n/a field | ✓ |
+| `david-and-mephibosheth` | Mercy | **Charity** | ✓ | ✗ empty | — n/a field | ✗ |
+| `the-cherry-tree` | Honesty | **Justice** | ✓ | ✗ empty | — n/a field | ✓ |
+| `the-woodcutters-axe` | Honesty | **Justice** | ✓ | ✗ empty | — n/a field | n/a |
+| `the-three-men` | Courage | **Fortitude** | ✓ | ✗ empty | — n/a field | n/a |
+| `the-ant-and-the-grasshopper` | Prudence | **Prudence** | ✓ | ✓ concrete | — n/a field | n/a |
+| `the-boy-and-the-filberts` | Temperance | **Temperance** | ✓ | ✓ concrete | — n/a field | n/a |
+
+Legend: ✓ present/conforming · ✗ missing · n/a field = the CMS has no such field
+yet (see Schema Gaps).
+
+## Canon Mapping — RESOLVED (engineering)
+
+Before C1, four stories carried orphan sub-virtue labels (`Kindness`, `Mercy`,
+`Honesty`×2) that matched no canon virtue, so they never appeared on a virtue
+hub and their story-page eyebrow did not link. `Courage` already resolved to
+`Fortitude` via the canon alternate name.
+
+C1 adds a sub-virtue → canon bridge in `src/lib/virtues.ts`
+(`SUB_VIRTUE_TO_CANON_SLUG`), sourced from the Writing Vault canon reference
+(PRO-57):
+
+- `kindness` → **Charity** (compassion freely given)
+- `mercy` → **Charity** (covenant love shown where judgment is expected)
+- `honesty` → **Justice** (giving others the truth they are owed)
+
+Result: **all 7 stories now map to a canon virtue (0 orphans)**, verified by
+smoke test. The stored `virtue` field stays free-text so the eyebrow can still
+display the sub-virtue angle ("A story of kindness") while linking up to the
+correct canon hub. No story prose, title, summary, or reflection was edited.
+
+This bridge is the engineering equivalent of a `canonicalVirtue` field: the
+canon never changes, so it lives in-repo (the same graceful-degradation
+principle as the seven virtues and the story fallback in `stories.ts`) rather
+than in the CMS.
+
+## Schema / Render Consistency
+
+End-to-end wiring confirmed in `basehub.ts` → `stories.ts` → render/metadata:
+
+| Field | In Basehub schema | Queried | Rendered | Status |
+| --- | --- | --- | --- | --- |
+| `title` (`_title`) | ✓ | ✓ | ✓ h1 + metadata | OK |
+| `slug` (`_slug`) | ✓ | ✓ | ✓ route | OK |
+| `summary` | ✓ | ✓ | ✓ meta description + cards | OK |
+| `content` | ✓ | ✓ | ✓ body | OK |
+| `virtueDescription` | ✓ | ✓ | ✓ moral card | OK |
+| `virtue` | ✓ | ✓ | ✓ eyebrow + canon bridge | OK |
+| `imageAlt` (`image.alt`) | ✓ | ✓ | ✓ hero `alt` | wired; content gap (see below) |
+| `canonicalVirtue` | ✗ (derived in-repo) | n/a | ✓ via bridge | OK (by design) |
+| `source` | ✗ | ✗ | ✗ | **GAP** |
+
+### Gaps (delegated, do not block C1 engineering)
+
+1. **`imageAlt` content gap** — the field is wired end-to-end, but 5 of 7
+   stories have empty `image.alt` in Basehub, so the page falls back to the
+   generic `Illustration for <title>`. This is a content backfill, not a code
+   bug. Owner: Margaret / illustration. → child issue.
+2. **`source` schema gap** — the contract lists a `source` provenance note, but
+   Basehub's `StoriesItem` has no `source` field and nothing renders it. This is
+   the one true unmet contract field. Needs an additive Basehub schema field
+   plus wiring through `basehub.ts` → `stories.ts` → render. → child issue.
+
+## Acceptance
+
+- Every story maps to a canon virtue: **met** (0 orphans, verified).
+- Turnkey "new virtue" checklist documented in-repo: **met**
+  (`content/vault/new-virtue-checklist.md`).
+- Full field-contract conformance: **met except** the two delegated gaps above,
+  which are content/CMS-schema work, not engineering blockers.

--- a/content/vault/catalog-audit.md
+++ b/content/vault/catalog-audit.md
@@ -64,7 +64,7 @@ End-to-end wiring confirmed in `basehub.ts` → `stories.ts` → render/metadata
 | `virtue` | ✓ | ✓ | ✓ eyebrow + canon bridge | OK |
 | `imageAlt` (`image.alt`) | ✓ | ✓ | ✓ hero `alt` | wired; content gap (see below) |
 | `canonicalVirtue` | ✗ (derived in-repo) | n/a | ✓ via bridge | OK (by design) |
-| `source` | ✗ | ✗ | ✗ | **GAP** |
+| `source` | ✗ (CMS field pending) | ✓ (with fallback) | ✓ provenance line + JSON-LD | code wired (PRO-62); CMS field + backfill pending |
 
 ### Gaps (delegated, do not block C1 engineering)
 
@@ -73,9 +73,12 @@ End-to-end wiring confirmed in `basehub.ts` → `stories.ts` → render/metadata
    generic `Illustration for <title>`. This is a content backfill, not a code
    bug. Owner: Margaret / illustration. → child issue.
 2. **`source` schema gap** — the contract lists a `source` provenance note, but
-   Basehub's `StoriesItem` has no `source` field and nothing renders it. This is
-   the one true unmet contract field. Needs an additive Basehub schema field
-   plus wiring through `basehub.ts` → `stories.ts` → render. → child issue.
+   Basehub's `StoriesItem` has no `source` field. PRO-62 has wired it through
+   the code (`basehub.ts` → `stories.ts` → story page + Article JSON-LD), with a
+   query fallback so the catalog is safe whether or not the field exists.
+   Remaining: add the `source` Text field in Basehub and backfill notes —
+   turnkey steps and proposed notes in `content/vault/source-field-backfill.md`.
+   Owner: Margaret (CMS field + editorial backfill).
 
 ## Acceptance
 

--- a/content/vault/drift-diagnosis.md
+++ b/content/vault/drift-diagnosis.md
@@ -1,0 +1,208 @@
+# Drift Diagnosis
+
+Compared on: 2026-06-20
+
+Gold-standard set:
+
+- `exemplars/androcles-and-the-lion.md`
+- `exemplars/david-and-mephibosheth.md`
+- `exemplars/the-cherry-tree.md`
+
+Recent comparison set from Basehub:
+
+- `The Woodcutter's Axe` (`the-woodcutters-axe`)
+- `The Three Men` (`the-three-men`)
+- `The Boy and the Filberts` (`the-boy-and-the-filberts`)
+- `The Ant and the Grasshopper` (`the-ant-and-the-grasshopper`)
+
+## Executive Diagnosis
+
+The recent stories drift in two different directions.
+
+`The Woodcutter's Axe` and `The Three Men` drift away from the originals through ornamental, motivational, and over-explained prose. They overbuild atmosphere, stack adjectives, and name the virtue too often before the narrative has earned it. They read more like polished moral retellings than a restrained family anthology.
+
+`The Boy and the Filberts` and `The Ant and the Grasshopper` recover much of the desired bedtime voice: concrete scenes, domestic scale, character action, and clean moral pressure. Their remaining drift is mostly structural: longer word counts and moral reflections that are stronger than the legacy originals but may become too essay-like if copied without restraint.
+
+The A2 writing-guide update should therefore not merely say "be warm" or "be literary." It needs enforceable rules against ornamental overbuilding, virtue-frontloading, and modern motivational cadence, while preserving the stronger concrete scene work found in the best recent drafts.
+
+## What The Originals Establish
+
+The three locked originals share a practical pattern:
+
+- A person is placed in a situation immediately: Androcles enters a cave; David remembers a promise; George tests a hatchet.
+- The moral pressure is visible before the virtue is explained: a thorn, a vulnerable rival's grandson, a father's question.
+- Most sentences are plain and sequential. They advance action more often than mood.
+- The diction is familiar enough for read-aloud use. Elevated words appear sparingly and usually name real story stakes.
+- The story closes soon after the decisive moral action. The reflection is brief, not a second essay.
+- Bedtime length stays tight: 303 to 487 words.
+
+These are tone exemplars, not perfect field-contract exemplars. They predate the current seven-virtue canon and structured-content standard, so their sub-virtue labels and in-body reflections should not be copied as production practice.
+
+## Concrete Deviations In Recent Stories
+
+### 1. Openings Became More Atmospheric Than Situational
+
+Originals begin with a character and circumstance:
+
+- Androcles is escaping slavery and finds a cave.
+- David is king and remembers Jonathan.
+- George has a hatchet and a farmyard temptation.
+
+Drifted openings often linger on scenic mood before story pressure:
+
+- `The Woodcutter's Axe` opens with dawn, soft gold, birds, steady labor, and a contented heart before the axe falls.
+- `The Three Men` opens with a wide plain, dazzling sky, a tower of gold, and imperial scale before the three men are morally tested.
+
+Fix for A2: the first paragraph must introduce the actor, setting, and moral pressure. Atmosphere may serve the action, but it cannot delay it.
+
+### 2. Adjectives And Intensifiers Started Carrying The Prose
+
+The originals use plain, concrete nouns and verbs. The weaker recent stories lean on adjectives and adverbs:
+
+- `gentle glow`, `soft gold`, `humble woodcutter`, `quiet joy`, `fateful swing`, `shimmering depths`, `radiant with heavenly light`.
+- `wide, sun-baked plain`, `dazzling Babylonian sky`, `towering statue`, `relentless heat`, `vast empire`, `glittering idol`.
+
+This creates a storybook sheen but weakens trust. It feels composed rather than told.
+
+Fix for A2: require a pass that cuts stacked modifiers. Keep the one concrete modifier that clarifies the scene; remove the rest.
+
+### 3. Virtue Was Named Too Early And Too Often
+
+The original pattern is "show first, name after." `The Woodcutter's Axe` tells us the woodcutter has "honest labor," "humble honesty," "sincerity," "simple heart," and "truthful spirit." `The Three Men` states "quiet courage," "unshakable faith," "integrity untouched," and "faith proven true."
+
+The result is moral redundancy. The reader is told how to evaluate the character before the action has made the case.
+
+Fix for A2: name the virtue once in the body only if needed, preferably near or after the decisive choice. The CMS `virtueDescription` carries the explicit reflection.
+
+### 4. Sentence Rhythm Became Grand And Predictable
+
+The weaker recent stories often use long, balanced sentences with tidy moral cadence. They sound smooth on the page but heavier aloud.
+
+Examples of the pattern:
+
+- Scene-setting clause + ornamental phrase + moral state.
+- Dialogue tag + adverb + virtue word.
+- Final sentence that turns an object into a symbolic thesis.
+
+The originals use simpler alternation: setup, action, short fear beat, consequence. `The Cherry Tree` especially shows the target rhythm: "He took a deep breath, met his father's gaze, and said..." The sentence serves the moment.
+
+Fix for A2: add a read-aloud rhythm check. If three consecutive sentences have the same polished, balanced shape, revise for plain sequence and shorter beats.
+
+### 5. Endings Started Explaining The Symbol Instead Of Trusting The Image
+
+`The Woodcutter's Axe` ends by hanging the axes "above the hearth" as "symbols of the quiet strength of honesty." This tells the reader how to interpret the image. `The Three Men` closes with integrity and courage named again after the furnace has already shown them.
+
+The stronger recent `The Boy and the Filberts` ends with the boy eating the filberts, which is closer to the original standard. `The Ant and the Grasshopper` ends on a small practical line: "You could." Those endings trust the story.
+
+Fix for A2: close on an earned image or action when possible. Put direct moral reflection in `virtueDescription`, not as a second ending in the body.
+
+### 6. Length Expanded Beyond Bedtime Tightness
+
+Originals:
+
+- `The Cherry Tree`: 303 words
+- `Androcles and the Lion`: 423 words
+- `David and Mephibosheth`: 487 words
+
+Recent stories:
+
+- `The Boy and the Filberts`: 548 words
+- `The Woodcutter's Axe`: 604 words
+- `The Three Men`: 773 words
+- `The Ant and the Grasshopper`: 815 words
+
+Longer is not automatically wrong, but the expansion must buy narrative clarity, not ornament. `The Ant and the Grasshopper` earns some length through developed mercy and practical counsel; `The Three Men` spends too much of its length on grandeur already supplied by the biblical source.
+
+Fix for A2: set a default target of 350-650 words for most retellings, with exceptions requiring a stated reason in the brief.
+
+### 7. Canon Labels Remain Inconsistent
+
+The locked originals and some recent stories use sub-virtues as stored labels: Kindness, Mercy, Honesty. `The Three Men` uses Courage while the product canon calls the virtue `Fortitude` with Courage as the plain-language angle. Newer stories correctly use `Temperance` and `Prudence`.
+
+Fix for A2 and C1: every brief and catalog record must name a canonical virtue from the seven and, if useful, a sub-virtue angle. Do not let the sub-virtue become the page taxonomy.
+
+### 8. Metadata And Body Boundaries Are Still Uneven
+
+`The Woodcutter's Axe` includes a trailing `***` in the body, which is not narrative. Several records have empty image alt text. The original `Androcles` summary is keyword-rich compared with the restrained anthology target.
+
+Fix for A2/C1: reinforce that the story body is narrative only, and metadata/search work belongs in structured fields: summary, metadata, alt text, source note, and internal-link recommendations.
+
+## Story-by-Story Notes
+
+### The Woodcutter's Axe
+
+Verdict: revise pattern. Strong plot fit, weak restraint.
+
+Concrete issues:
+
+- Opens with atmosphere before problem.
+- Overuses soft, pious adjectives.
+- Names honesty/contentment repeatedly.
+- Adds a symbolic hearth ending after the fable has already landed.
+- Leaves a non-narrative `***` marker in the body.
+
+Production fix:
+
+- Start closer to the axe falling.
+- Cut 100-150 words of ornament.
+- Let Hermes' test prove honesty; save the explicit lesson for `virtueDescription`.
+
+### The Three Men
+
+Verdict: revise pattern. Strong source, inflated register.
+
+Concrete issues:
+
+- Grand opening pushes the piece toward epic spectacle rather than bedside clarity.
+- "One true God" and command explanation are acceptable source context, but the body leans toward sermon when paired with repeated courage/faith language.
+- Nebuchadnezzar's emotional reactions are heightened beyond the source needs.
+- The final paragraph restates the moral after the rescue has already shown it.
+
+Production fix:
+
+- Keep the furnace, command, refusal, rescue, and king's response.
+- Reduce imperial scale-setting and repeated moral naming.
+- Map canon carefully: likely `Faith` as the primary virtue, with `Fortitude` as the courage angle.
+
+### The Boy and the Filberts
+
+Verdict: closest to current target; use as a secondary live comparison with one caution.
+
+Strengths:
+
+- Opens immediately on a boy and a jar.
+- The moral is embodied by the trapped hand.
+- The mother's correction is gentle, practical, and not preachy.
+- Ending trusts the image.
+
+Caution:
+
+- At 548 words it is longer than the original fable requires, but the expansion mostly serves read-aloud texture. Do not let future drafts inflate similarly simple fables unless the added beats clarify the choice.
+
+### The Ant and the Grasshopper
+
+Verdict: strong modernized bedtime retelling; useful, but longer than the original vault pattern.
+
+Strengths:
+
+- Opens on a concrete summer scene with immediate contrast between music and work.
+- Makes prudence cheerful rather than anxious.
+- Avoids cruelty by letting the ant feed Grasshopper while still naming the truth.
+- Dialogue carries the lesson naturally.
+
+Cautions:
+
+- 815 words is long for the default pattern.
+- The `virtueDescription` is essay-like and should be watched so reflections do not become mini-homilies.
+
+## A2 Inputs
+
+The writing-guide hardening should add:
+
+- a first-paragraph rule: actor + setting + moral pressure by the end of paragraph one;
+- a modifier rule: no stacked ornamental adjectives unless a concrete detail needs them;
+- a virtue-naming rule: show before naming; default to one named virtue moment in the body;
+- a body-boundary rule: no separators, related links, FAQ/SEO copy, or second moral endings inside `content`;
+- a length rule: default 350-650 words unless the brief approves a longer treatment;
+- a canon rule: canonical virtue plus optional sub-virtue angle on every brief and record;
+- a read-aloud check: cut any sentence that sounds like promotional, devotional, or motivational copy rather than story.

--- a/content/vault/exemplars/androcles-and-the-lion.md
+++ b/content/vault/exemplars/androcles-and-the-lion.md
@@ -1,0 +1,53 @@
+# Androcles and the Lion
+
+## Basehub Export
+
+- Exported: 2026-06-20
+- Basehub id: `mGA2xHFwxKmpXNgYoKWYr`
+- Slug: `androcles-and-the-lion`
+- Stored virtue label: `Kindness`
+- Canon mapping for future use: `Charity` angle, because the central act is compassion freely given to a suffering creature, returned in loyal love.
+- Summary: Discover the timeless tale of Androcles and the Lion—a story of compassion, courage, and unexpected friendship in ancient Rome. Learn how a simple act of kindness changed two lives forever in this inspiring fable about empathy and the rewards of true loyalty.
+- Virtue reflection: Kindness, even in the smallest acts, can forge unbreakable bonds. When we show compassion, it can return to us in unexpected and powerful ways.
+- Image alt: 
+- Audio URL present: yes
+- Reading time: 3 minutes
+- Word count: 423
+
+## Locked Story Body
+
+Androcles was a man who had once been a slave in ancient Rome. Tired of the harsh treatment he received, he decided to escape one night, fleeing deep into the dense forests surrounding the city. For days, Androcles wandered, lost and hungry, until he stumbled upon a hidden cave. Hoping for shelter, he cautiously made his way inside.
+
+As he entered the cave, a low, rumbling growl echoed from the darkness. His heart pounded as a massive lion stepped into the light. Androcles froze, certain that the beast would strike him down. But as the lion approached, something strange happened. The lion did not attack. Instead, it limped toward Androcles, its paw lifted as if asking for help.
+
+Androcles, trembling but curious, knelt down. In the lion’s paw, he saw a large, sharp thorn lodged deep in its flesh. The lion whimpered in pain. Carefully and with great gentleness, Androcles reached for the paw and, with one quick motion, removed the thorn. The lion roared, not in anger, but in relief. It licked its paw and then, to Androcles' surprise, gently nuzzled him in gratitude before lying down to rest.
+
+For several days, Androcles remained in the cave, with the lion as his companion. They shared food and a silent bond of trust grew between them.
+
+But their peaceful time was cut short when Androcles was discovered by Roman soldiers and captured. He was taken back to the city and sentenced to death for his escape. The punishment was to be thrown into the Colosseum, where a fierce lion would be set upon him as a spectacle for the crowd.
+
+On the day of the execution, Androcles was led into the arena. The crowd roared with excitement as the lion was released from its cage, and it rushed toward Androcles with terrifying speed. But as the lion neared, something incredible happened. The great beast slowed, then stopped, recognizing the man standing before him. It was the same lion Androcles had saved in the cave.
+
+Instead of attacking, the lion padded up to Androcles and affectionately licked his hand. The crowd, stunned by the sight, fell silent. Word of this extraordinary act of kindness and loyalty spread quickly, and soon the emperor himself ordered Androcles to be released, declaring that any man who could inspire such loyalty in a lion deserved his freedom.
+
+Androcles and the lion were reunited, their bond a testament to the power of empathy and kindness. From that day forward, they were inseparable, living in peace, both free and grateful.
+
+## Editorial Annotation
+
+### Why It Works
+
+- Opening on scene: a named man, a place, and an immediate problem. It does not begin with an essay about kindness.
+- Sentence rhythm: short fear beats in the cave ("His heart pounded"; "Androcles froze") alternate with longer explanatory sentences, which makes it easy to read aloud without monotony.
+- Diction: plain verbs carry the action: wandered, entered, froze, limped, knelt, removed. The few heightened words serve the scene rather than ornamenting it.
+- Virtue landing: kindness appears as a risky act before it is named. Androcles helps the lion while frightened and powerless; the reflection follows the action.
+- Length: 423 words, compact enough for bedtime, with one clear turn from cave to arena.
+
+### Keep For Future Drafts
+
+- Let the creature or childlike reader-facing image do real work. The lifted paw is more persuasive than a paragraph explaining compassion.
+- Keep the final sentence quiet. It names the virtue once and closes the emotional arc.
+
+### Watchouts
+
+- The Basehub summary is SEO-forward and should not be used as a model for new summaries without restraint.
+- The stored virtue label is a sub-virtue, not one of the seven canonical virtue pages.

--- a/content/vault/exemplars/david-and-mephibosheth.md
+++ b/content/vault/exemplars/david-and-mephibosheth.md
@@ -1,0 +1,55 @@
+# David and Mephibosheth
+
+## Basehub Export
+
+- Exported: 2026-06-20
+- Basehub id: `PHavBnWtZhoO41NmyjvZz`
+- Slug: `david-and-mephibosheth`
+- Stored virtue label: `Mercy`
+- Canon mapping for future use: `Charity` angle with `Justice` support, because David gives covenant love where political custom would expect judgment.
+- Summary: A story of mercy, loyalty, and honoring the bonds of friendship, even across generations.
+- Virtue reflection: Mercy is more than kindness; it is compassion shown when judgment is expected. David's mercy to Mephibosheth shows that true strength lies not in power, but in choosing compassion over custom and kindness over revenge.
+- Image alt: 
+- Audio URL present: no
+- Reading time: 3 minutes
+- Word count: 487
+
+## Locked Story Body
+
+Years had passed since David had become king of Israel, and his rule was marked by the justice and mercy that had guided him since his youth. Though he was now a powerful king, David had not forgotten his dear friend Jonathan, son of Saul, Israel’s former king. Jonathan had been more than a friend; he was a brother in spirit, standing by David’s side despite his father’s bitter jealousy and attempts to kill David. Jonathan’s loyalty and courage had saved David’s life on more than one occasion, and even after Jonathan’s death in battle, David’s heart held a sacred promise he had made to him—to show kindness to his family, no matter the cost.
+
+One day, moved by this memory, David asked aloud in his palace, “Is there anyone left in the house of Saul to whom I can show kindness for Jonathan’s sake?” His words surprised those around him, for the custom was for kings to eliminate the families of their rivals, securing the throne. But David, ever faithful to his promises, chose a different path.
+
+He called for Ziba, a servant who had once belonged to Saul’s household, and asked him, “Is there anyone left from Saul’s family whom I can show God’s kindness?”
+
+Ziba replied, “There is still a son of Jonathan. His name is Mephibosheth, and he lives in Lo Debar. However, my lord, he is crippled in both feet.”
+
+Without hesitation, David ordered for Mephibosheth to be brought to Jerusalem. Word of this summons must have struck fear into Mephibosheth’s heart, for he was the grandson of Saul, and he knew well that his life was at the mercy of the king. As he arrived, he bowed low, trembling before David, fearing for his life.
+
+But David looked upon Mephibosheth not with anger or judgment but with the kindness and mercy that had shaped his reign. He spoke gently, “Do not be afraid. I will surely show you kindness for the sake of your father Jonathan. I will restore to you all the land that belonged to your grandfather Saul, and you will always eat at my table.”
+
+Mephibosheth, overwhelmed by this unexpected mercy, looked up in amazement. “What is your servant,” he asked, “that you should show kindness to a dead dog like me?” He, who had lived far from the palace, had never expected such kindness, let alone from the king himself.
+
+From that day on, Mephibosheth dined regularly at King David’s table, as if he were one of David’s own sons. David restored all the land that had belonged to Saul’s family to Mephibosheth, keeping his promise to Jonathan with unwavering faithfulness.
+
+In honoring Mephibosheth, David showed that true kindness transcends custom, and that a promise made in friendship is one that endures. David’s loyalty to Jonathan created a bond that defied time and death, a testament to the power of mercy and the sacred nature of friendship.
+
+## Editorial Annotation
+
+### Why It Works
+
+- Opening on scene: the first paragraph gives David a remembered promise and a royal setting; the story begins with a king who has power and a debt of friendship.
+- Sentence rhythm: longer covenant-background sentences are followed by simple spoken questions, letting the read-aloud voice breathe.
+- Diction: the prose uses elevated but familiar words: palace, promise, custom, table. It stays biblical in register without becoming archaic.
+- Virtue landing: mercy is shown through a reversal of expected judgment. Mephibosheth arrives fearing death and receives a place at the king's table.
+- Length: 487 words, enough context for the scriptural situation without losing the bedtime shape.
+
+### Keep For Future Drafts
+
+- Give the reader the social pressure around the choice. The custom of rival kings makes David's mercy concrete.
+- Let dialogue carry the moral turn. "Do not be afraid" does more than a lecture on compassion.
+
+### Watchouts
+
+- The first paragraph names virtues before fully dramatizing them; future drafts should delay abstraction a little longer when possible.
+- The stored virtue label is a sub-virtue. New briefs must map it to the seven-virtue canon.

--- a/content/vault/exemplars/the-cherry-tree.md
+++ b/content/vault/exemplars/the-cherry-tree.md
@@ -1,0 +1,51 @@
+# The Cherry Tree
+
+## Basehub Export
+
+- Exported: 2026-06-20
+- Basehub id: `QEIECGxkM3bcDNVv9lrCG`
+- Slug: `the-cherry-tree`
+- Stored virtue label: `Honesty`
+- Canon mapping for future use: `Justice` angle with `Fortitude` support, because George gives his father the truth he is owed despite fear of punishment.
+- Summary: A story about the honesty of our nation's first president and the importance of character.
+- Virtue reflection: Honesty is the foundation of trust and respect. The courage to tell the truth, even when it is difficult, is a virtue that defines one’s character.
+- Image alt: 
+- Audio URL present: yes
+- Reading time: 2 minutes
+- Word count: 303
+
+## Locked Story Body
+
+Young George Washington was known for his curiosity and energy, traits that would later serve him well in leading a nation. One day, after being given a shiny new hatchet, George’s excitement got the better of him. He wandered around the family farm, eager to test his new tool on the trees lining the yard.
+
+In his innocent haste, George came upon a tall cherry tree. Without much thought, he swung his hatchet and delivered a sharp blow to the tree’s trunk. The cut was deep, and George quickly realized the damage he'd caused. The bark split, and the tree was unlikely to survive.
+
+Later that day, George’s father, Augustine Washington, noticed the scarred tree. It was one of his favorites, planted many years ago. With concern and frustration, he sought out his son. “George,” his father called in a firm voice, “do you know what happened to the cherry tree in the yard?”
+
+George, heart pounding, felt the weight of his father’s question. He knew that admitting the truth could lead to punishment. Yet something inside him, something his parents had taught him, pressed him to speak up.
+
+He took a deep breath, met his father’s gaze, and said, “Father, I cannot tell a lie. I cut the tree with my hatchet.”
+
+For a moment, the air seemed heavy. Augustine Washington’s face softened. He put a hand on his son’s shoulder, nodding slowly. “My son, your honesty means more to me than a thousand cherry trees. You’ve shown great courage in telling the truth, and that is something I will always be proud of.”
+
+Though George had damaged the tree, he had done something far more valuable that day—he upheld his character. And in that moment, George learned that a man’s word, when given in truth, was worth more than anything material.
+
+## Editorial Annotation
+
+### Why It Works
+
+- Opening on scene: the boy, the hatchet, and the farm arrive quickly. The story is about an action, not a premise.
+- Sentence rhythm: direct cause-and-effect sentences suit the moral simplicity of the tale. The story moves from mischief to fear to confession without padding.
+- Diction: household words dominate: father, tree, yard, hand, truth. The language fits a parent reading to a child.
+- Virtue landing: honesty appears at the moment of cost, when George has a clear reason to hide.
+- Length: 303 words, the tightest exemplar. It proves a story can be complete without scenic overbuilding.
+
+### Keep For Future Drafts
+
+- Keep the decisive moment uncluttered. The confession is one clean sentence.
+- Let physical gesture soften the moral. The father's hand on George's shoulder keeps the lesson warm.
+
+### Watchouts
+
+- The final paragraph turns reflective inside the story body. New production should put this kind of reflection in `virtueDescription` when the CMS structure permits.
+- The stored virtue label is a sub-virtue. New briefs must map it to the seven-virtue canon.

--- a/content/vault/new-virtue-checklist.md
+++ b/content/vault/new-virtue-checklist.md
@@ -1,0 +1,93 @@
+# "New Virtue" Turnkey Checklist
+
+Goal: once the catalog is consistent (PRO-61), adding a story is **purely
+additive**. Follow this checklist and a new story drops into the right canon hub,
+links correctly, and conforms to the field contract — no structural changes
+required.
+
+Read `writing.md` (field contract, voice, SEO boundary) and `PRODUCT.md` (the
+seven-virtue canon) before drafting. Margaret owns editorial approval and Basehub
+publishing; engineering owns schema/render/scripts.
+
+## 1. Pick the canon virtue (editorial — Margaret)
+
+- Every story maps to exactly one of the seven canon virtues: **Prudence,
+  Justice, Fortitude, Temperance, Faith, Hope, Charity**.
+- A story may lead with a sub-virtue *angle* (kindness, mercy, honesty, patience,
+  courage, self-control, …). The angle is a presentation choice; the canon virtue
+  is the taxonomy. Decide both in the brief.
+
+## 2. If the angle is a NEW sub-virtue label (engineering — one line)
+
+The CMS `virtue` field is free-text and drives both the story-page eyebrow and
+the virtue-hub grouping. A label only resolves to a canon hub if it is either:
+
+- a canon **title** (`Prudence`, `Justice`, …), or
+- a canon **`alternateName`** in `src/data/virtues.json` (`Courage`→Fortitude,
+  `Love`→Charity), or
+- listed in **`SUB_VIRTUE_TO_CANON_SLUG`** in `src/lib/virtues.ts`.
+
+If the new label is none of these, it will be an **orphan** (no hub, no eyebrow
+link). To prevent that, add one line to `SUB_VIRTUE_TO_CANON_SLUG`:
+
+```ts
+// src/lib/virtues.ts
+const SUB_VIRTUE_TO_CANON_SLUG: Record<string, string> = {
+  kindness: 'charity',
+  mercy: 'charity',
+  honesty: 'justice',
+  patience: 'temperance', // ← example: add the new angle → canon slug
+}
+```
+
+Use the canon **slug** (lowercase) on the right. Confirm the mapping with
+Margaret (it is a canon decision). No new label = no code change needed.
+
+## 3. Fill the field contract (editorial)
+
+Every publish-ready story must provide:
+
+- `title` — plain anthology title (not an SEO subtitle)
+- `slug` — stable, lowercase, hyphenated
+- `summary` — short reader-facing summary (also the meta description)
+- `content` — narrative only; no SEO scaffolding, separators, related-reading, or
+  second moral ending in the body
+- `virtueDescription` — the single moral/reflection (renders in the moral card)
+- `virtue` — the canon title or an angle that resolves per step 2
+- `imageAlt` — concrete alt text for the illustration (Basehub `image.alt`).
+  **Do not leave empty** — empty alt falls back to a generic string and fails the
+  contract.
+- `audioUrl` — only if narration exists
+- `source` — provenance note *(pending the additive Basehub `source` field; until
+  then record it in the brief/publish notes)*
+
+## 4. Publish (editorial — Margaret)
+
+- Publish to Basehub. `getAllStories()` / `getStoryBySlug()` pick it up; the story
+  route and virtue hub are statically generated from the catalog.
+- Webhook `/revalidate-sitemap` refreshes the sitemap on content change.
+
+## 5. Verify (anyone)
+
+- Story page renders: `https://www.classicalvirtues.com/stories/<slug>`
+- Eyebrow "A story of <angle>" **links** to `/virtues/<canon-slug>` (not plain
+  text → that means orphan; revisit step 2).
+- Story appears on its canon virtue hub: `/virtues/<canon-slug>`.
+- Hero image alt is concrete (not "Illustration for …").
+- Story is in the sitemap.
+
+Quick local check that a label resolves to canon before publishing:
+
+```bash
+node -e 'const V=require("./src/data/virtues.json"),S={kindness:"charity",mercy:"charity",honesty:"justice"};
+const n=process.argv[1].toLowerCase();
+const d=V.find(v=>n===v.title.toLowerCase()||n===(v.alternateName||"").toLowerCase());
+console.log(d?d.slug:(S[n]||"ORPHAN — add to SUB_VIRTUE_TO_CANON_SLUG"))' "Kindness"
+```
+
+## New canon virtue (rare)
+
+The seven canon virtues are fixed. Only if the canon itself changes: add the
+entry to `src/data/virtues.json`, run `scripts/seed-virtues.mjs` to mirror it into
+Basehub, and update `PRODUCT.md`/`writing.md`. This is a product decision, not
+routine story work.

--- a/content/vault/source-field-backfill.md
+++ b/content/vault/source-field-backfill.md
@@ -1,0 +1,63 @@
+# `source` Provenance Field — CMS Setup & Backfill
+
+Workstream for [PRO-62]. The `source` field is the last field-contract field
+(see `writing.md`) that had no CMS home. The **rendering and query wiring is
+done and merged** (`src/lib/basehub.ts` → `src/lib/stories.ts` → story page +
+Article JSON-LD). What remains needs Basehub dashboard access and editorial
+sign-off; until then nothing renders (the line is omitted when `source` is
+empty, so there is no regression).
+
+## 1. Add the Basehub field (dashboard / schema access)
+
+In the Basehub `Stories` collection, add a field:
+
+- **API name:** `source` (must be exactly `source` — the query selects it by
+  this name).
+- **Type:** **Text** (single-line string). **Not** Rich Text — the code reads
+  `story.source` as a plain string (`Scalars['String']`); a rich-text field
+  returns an object and will not render.
+- **Required:** no. Leave optional so existing items stay valid and stories
+  without a known source simply render no provenance line.
+- **Label/help text (suggested):** "Public-domain or classical source note,
+  e.g. `From Aesop's Fables`. Shown as a small attribution line under the story,
+  outside the narrative. Leave blank if the source is uncertain."
+
+After the field exists, regenerate the generated types so the optional cast and
+the runtime fallback in `basehub.ts` become inert:
+
+```
+pnpm run basehub   # regenerates basehub-types.d.ts to include `source`
+```
+
+No code change is required after that — the query already selects `source`
+first and falls back to the base selection only while the field is absent.
+
+## 2. Backfill source notes (Margaret — editorial)
+
+`writing.md` rule: **provenance is accurate or uncertainty is cut.** Where the
+source is uncertain, leave the field blank (nothing renders). The notes below
+are engineering *suggestions* drawn from the locked exemplars and the catalog;
+Margaret owns the final wording.
+
+| Story (slug) | Suggested `source` | Confidence |
+| --- | --- | --- |
+| `androcles-and-the-lion` | From Aesop's Fables | high (Aesopic tradition; also recorded by Aulus Gellius) |
+| `the-ant-and-the-grasshopper` | From Aesop's Fables | high |
+| `the-boy-and-the-filberts` | From Aesop's Fables | high |
+| `the-woodcutters-axe` | From Aesop's Fables ("Mercury and the Woodman") | high |
+| `david-and-mephibosheth` | Retold from 2 Samuel 9 | high (Hebrew Bible, public domain) |
+| `the-cherry-tree` | A traditional tale popularized by Mason Locke Weems, *The Life of Washington* (1806) | medium — famously apocryphal; phrase so it does not assert historical fact |
+| `the-three-men` | — | **unknown — leave blank** pending Margaret's source check |
+
+Style: keep it short and plain (an attribution, not a citation). Prefer
+"From Aesop's Fables" over a full bibliographic reference. The rendered line is
+`Source: <value>`.
+
+## Acceptance (PRO-62)
+
+- [x] `source` wired end-to-end in code (query → `StoryData` → render +
+      structured data), type-checked and linted.
+- [ ] `source` field added in Basehub (Text, optional).
+- [ ] Source notes backfilled per the table above (Margaret-approved).
+- [ ] Verified on a deploy: provenance line renders under at least one story and
+      is absent where `source` is blank.

--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -1,4 +1,5 @@
 import { ImageResponse } from 'next/og'
+import { fitOgText, fitOgTitle } from '@/lib/seo'
 
 export const runtime = 'edge'
 
@@ -6,6 +7,12 @@ export async function GET(request: Request) {
   const { searchParams } = new URL(request.url)
   const title = searchParams.get('title')
   const virtue = searchParams.get('virtue')
+
+  // Overflow guard: scale the font down for long strings and hard-truncate
+  // anything that would still spill past the 1200×630 canvas, so the footer
+  // branding can never be pushed off the image.
+  const heading = fitOgTitle(title ?? '')
+  const subtitle = virtue ? fitOgText(virtue) : null
 
   return new ImageResponse(
     (
@@ -25,18 +32,18 @@ export async function GET(request: Request) {
       >
         <h1
           style={{
-            fontSize: '64px',
+            fontSize: `${heading.fontSize}px`,
             fontFamily: 'Cormorant Garamond',
             marginBottom: '20px',
           }}
         >
-          {title || 'Classical Virtues'}
+          {heading.text}
         </h1>
-        {virtue && (
+        {subtitle && (
           <p
-            style={{ fontSize: '36px', fontFamily: 'Nunito', marginBottom: '20px' }}
+            style={{ fontSize: `${subtitle.fontSize}px`, fontFamily: 'Nunito', marginBottom: '20px' }}
           >
-            {virtue}
+            {subtitle.text}
           </p>
         )}
         <span style={{ fontSize: '28px', fontFamily: 'Nunito', opacity: 0.7 }}>

--- a/src/app/stories/[slug]/page.tsx
+++ b/src/app/stories/[slug]/page.tsx
@@ -146,6 +146,9 @@ export default async function Post({ params }: { params: Params }) {
     },
     "articleSection": "Moral Stories",
     "keywords": [story.virtue, "virtue", "moral story", "classical virtues"],
+    // Provenance as structured data (allowed SEO surface): the public-domain or
+    // classical source this retelling is based on.
+    ...(story.source ? { "isBasedOn": story.source } : {}),
     ...(story.audioUrl
       ? {
           "audio": {
@@ -193,6 +196,13 @@ export default async function Post({ params }: { params: Params }) {
       <div className="prose prose-lg">
         {storyContent}
       </div>
+      {story.source && (
+        // Provenance line: a quiet, structured attribution kept outside the
+        // narrative body and the moral card (SEO boundary, writing.md).
+        <p className="mt-6 text-sm italic text-muted-foreground">
+          Source: {story.source}
+        </p>
+      )}
       <Card className="bg-accent text-accent-foreground mt-8">
         <CardContent className="p-8">
           <div className="space-y-6">

--- a/src/app/stories/[slug]/page.tsx
+++ b/src/app/stories/[slug]/page.tsx
@@ -107,6 +107,15 @@ export default async function Post({ params }: { params: Params }) {
 
   const minutes = Math.max(1, Math.round(story.wordCount / 140));
   const virtueSlug = getVirtueSlugForStoryVirtue(story.virtue);
+  if (!virtueSlug) {
+    // Fail loudly: an unmapped virtue silently drops the virtue-hub link. Surface
+    // it in build/runtime logs so the editorial mismatch gets fixed, but keep the
+    // page rendering (plain-text virtue) per the graceful-degradation principle.
+    console.error(
+      `[virtue-mapping] Story "${story.slug}" has virtue "${story.virtue}" which maps to no canon entry. ` +
+        `The virtue-hub link will be missing — set the story virtue to a canon name or alias (see src/data/virtues.json).`,
+    );
+  }
   const storyContent = await renderStoryContent(story.content);
 
   const articleStructuredData = {
@@ -171,7 +180,7 @@ export default async function Post({ params }: { params: Params }) {
       <div className="relative w-full h-80 mb-8 overflow-hidden">
         <Image
           src={story.image}
-          alt={story.imageAlt || `Illustration for ${story.title}`}
+          alt={story.imageAlt}
           fill
           priority
           sizes="(max-width: 768px) 100vw, 768px"

--- a/src/lib/basehub.ts
+++ b/src/lib/basehub.ts
@@ -1,36 +1,63 @@
 import { basehub } from 'basehub'
-import type { StoriesItem } from '../../basehub-types'
+import type { StoriesItem, StoriesItemGenqlSelection } from '../../basehub-types'
 import '../../basehub.config' // Import the config to ensure it's loaded
 
-// Use BaseHub's generated types for full type safety
-export type Story = StoriesItem
+// Use BaseHub's generated types for full type safety. `source` (provenance
+// note, PRO-62) is an additive Basehub field: it does not appear on the
+// generated `StoriesItem` type until the field is created in the Basehub
+// dashboard and `pnpm run basehub` regenerates `basehub-types.d.ts`. We model
+// it as an optional extension here so the reader/render layer can consume it
+// immediately, and select it defensively (see `buildItemSelection`).
+export type Story = StoriesItem & { source?: string | null }
 
-// Fetch all stories with proper BaseHub caching
+// Base field selection shared by both story queries.
+const STORY_ITEM_FIELDS = {
+  _id: true,
+  _slug: true,
+  _title: true,
+  virtue: true,
+  image: {
+    url: true,
+    alt: true,
+  },
+  summary: true,
+  virtueDescription: true,
+  audioUrl: true,
+  content: {
+    markdown: true,
+    plainText: true,
+    readingTime: true,
+  },
+}
+
+/**
+ * Build the story field selection, optionally including the additive `source`
+ * provenance field. The cast is required because `source` is not yet part of
+ * the generated genql types; it is removed automatically (no code change) once
+ * the field exists in the schema and types are regenerated.
+ */
+function buildItemSelection(withSource: boolean): StoriesItemGenqlSelection {
+  const selection = withSource
+    ? { ...STORY_ITEM_FIELDS, source: true }
+    : { ...STORY_ITEM_FIELDS }
+  return selection as StoriesItemGenqlSelection
+}
+
+// Fetch all stories with proper BaseHub caching.
+// The query first selects the `source` provenance field and transparently
+// retries with the base selection if Basehub rejects it (i.e. the field has
+// not been added to the schema yet). This keeps the catalog rendering whether
+// or not `source` exists, and makes provenance self-activating once the field
+// lands — no second deploy required.
 export async function getAllStories(): Promise<Story[]> {
   try {
-    // Use BaseHub's recommended query method (draft config handled in basehub.config.ts)
-    const data = await basehub().query({
-      stories: {
-        items: {
-          _id: true,
-          _slug: true,
-          _title: true,
-          virtue: true,
-          image: {
-            url: true,
-            alt: true,
-          },
-          summary: true,
-          virtueDescription: true,
-          audioUrl: true,
-          content: {
-            markdown: true,
-            plainText: true,
-            readingTime: true,
-          },
-        },
-      },
-    })
+    let data
+    try {
+      data = await basehub().query({ stories: { items: buildItemSelection(true) } })
+    } catch {
+      // `source` may not be in the Basehub schema yet (PRO-62).
+      data = await basehub().query({ stories: { items: buildItemSelection(false) } })
+    }
 
     return data.stories.items as Story[]
   } catch (error) {
@@ -39,34 +66,17 @@ export async function getAllStories(): Promise<Story[]> {
   }
 }
 
-// Fetch a single story by slug with proper BaseHub caching
+// Fetch a single story by slug with proper BaseHub caching (same `source`
+// fallback as getAllStories above).
 export async function getStoryBySlug(slug: string): Promise<Story | null> {
   try {
-    const data = await basehub().query({
-      stories: {
-        __args: {
-          first: 100,
-        },
-        items: {
-          _id: true,
-          _slug: true,
-          _title: true,
-          virtue: true,
-          image: {
-            url: true,
-            alt: true,
-          },
-          summary: true,
-          virtueDescription: true,
-          audioUrl: true,
-          content: {
-            markdown: true,
-            plainText: true,
-            readingTime: true,
-          },
-        },
-      },
-    })
+    const args = { first: 100 }
+    let data
+    try {
+      data = await basehub().query({ stories: { __args: args, items: buildItemSelection(true) } })
+    } catch {
+      data = await basehub().query({ stories: { __args: args, items: buildItemSelection(false) } })
+    }
 
     // Find the story with matching slug
     const story = data.stories.items.find((item: Pick<Story, '_slug'>) => item._slug === slug)
@@ -75,4 +85,4 @@ export async function getStoryBySlug(slug: string): Promise<Story | null> {
     console.error('Error fetching story from Basehub:', error)
     return null
   }
-} 
+}

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,102 @@
+/**
+ * SEO-surface hardening helpers.
+ *
+ * These keep the metadata / OpenGraph / structured-data path resilient: a
+ * missing CMS field (summary, image alt) or an over-long string (OG overlay
+ * text) degrades gracefully instead of producing an empty meta description or a
+ * broken share image. None of these touch the story body or prose — they only
+ * harden the technical SEO surfaces named in the SEO contract (`SEO.md`).
+ */
+
+/** Brand-safe default used when a story has no usable summary at all. */
+export const DEFAULT_SUMMARY =
+  'A short story from the Classical Virtues anthology — a timeless tale that teaches a virtue through character and choice.'
+
+/**
+ * Collapse whitespace and trim a string into a single clean line, or '' when
+ * there is nothing usable.
+ */
+function clean(value: string | null | undefined): string {
+  return value?.replace(/\s+/g, ' ').trim() ?? ''
+}
+
+/**
+ * Truncate at a word boundary and append an ellipsis. Falls back to a hard cut
+ * when there is no sensible space to break on.
+ */
+function truncate(value: string, maxLen: number): string {
+  if (value.length <= maxLen) return value
+  const slice = value.slice(0, maxLen - 1)
+  const lastSpace = slice.lastIndexOf(' ')
+  const body = lastSpace > Math.floor(maxLen / 2) ? slice.slice(0, lastSpace) : slice
+  return `${body.trimEnd()}…`
+}
+
+/**
+ * Resolve the summary used for the meta description, OG/Twitter description,
+ * and Article schema. Fallback chain so the field is never empty (it is a
+ * single point of failure across four SEO surfaces):
+ *   1. the editorial `summary`
+ *   2. a trimmed excerpt of the story prose
+ *   3. a brand default
+ */
+export function resolveSummary(
+  summary: string | null | undefined,
+  plainText?: string | null,
+): string {
+  const editorial = clean(summary)
+  if (editorial) return editorial
+
+  const excerpt = clean(plainText)
+  if (excerpt) return truncate(excerpt, 155)
+
+  return DEFAULT_SUMMARY
+}
+
+/**
+ * Image alt text with a concrete, descriptive fallback when the CMS alt is
+ * empty or whitespace-only. Keeps the `<img alt>` wired end-to-end.
+ */
+export function resolveImageAlt(
+  alt: string | null | undefined,
+  title: string,
+): string {
+  return clean(alt) || `Illustration for ${title}`
+}
+
+/**
+ * Fit overlay text into the fixed 1200×630 OG canvas. Longer strings get a
+ * smaller font and anything beyond `max` characters is hard-truncated, so the
+ * "classicalvirtues.com" footer can never be pushed off the image.
+ */
+export function fitOgText(
+  value: string,
+  { max = 180, large = 36, medium = 30, small = 24 }: {
+    max?: number
+    large?: number
+    medium?: number
+    small?: number
+  } = {},
+): { text: string; fontSize: number } {
+  const text = truncate(clean(value), max)
+  let fontSize = large
+  if (text.length > 80) fontSize = medium
+  if (text.length > 140) fontSize = small
+  return { text, fontSize }
+}
+
+/**
+ * Fit the OG title (the prominent heading). Same idea as {@link fitOgText} but
+ * with a larger type scale and a tighter character budget.
+ */
+export function fitOgTitle(
+  value: string,
+  fallback = 'Classical Virtues',
+): { text: string; fontSize: number } {
+  const source = clean(value) || fallback
+  const text = truncate(source, 90)
+  let fontSize = 64
+  if (text.length > 36) fontSize = 52
+  if (text.length > 60) fontSize = 44
+  return { text, fontSize }
+}

--- a/src/lib/stories.ts
+++ b/src/lib/stories.ts
@@ -13,6 +13,13 @@ export interface StoryData {
   summary: string
   content: string
   virtueDescription: string
+  /**
+   * Public-domain / classical source note (e.g. "From Aesop's Fables").
+   * Optional: rendered as a small provenance line outside the story body when
+   * present, omitted entirely otherwise. Lives in a structured field, never in
+   * the narrative `content`, per the SEO boundary in `writing.md`.
+   */
+  source?: string
   audioUrl: string
   wordCount: number
 }
@@ -39,6 +46,9 @@ function basehubToStory(story: Story): StoryData | null {
     summary: resolveSummary(story.summary, story.content.plainText),
     content: story.content.markdown,
     virtueDescription: story.virtueDescription,
+    // Optional provenance note; omit when empty so nothing renders. `source`
+    // is an additive Basehub field (PRO-62) and may be absent on older items.
+    source: story.source?.trim() || undefined,
     audioUrl: story.audioUrl || '',
     wordCount: story.content.plainText.split(/\s+/).length,
   }

--- a/src/lib/stories.ts
+++ b/src/lib/stories.ts
@@ -1,4 +1,5 @@
 import { getAllStories as getAllBasehubStories, getStoryBySlug as getBasehubStoryBySlug, Story } from './basehub'
+import { resolveSummary, resolveImageAlt } from './seo'
 
 // Unified story interface
 export interface StoryData {
@@ -31,8 +32,11 @@ function basehubToStory(story: Story): StoryData | null {
     title: story._title,
     virtue: story.virtue,
     image: story.image.url,
-    imageAlt: story.image.alt || '',
-    summary: story.summary,
+    // Always populated: concrete CMS alt, else a descriptive fallback.
+    imageAlt: resolveImageAlt(story.image.alt, story._title),
+    // Always populated: editorial summary, else prose excerpt, else brand default.
+    // Feeds meta description, OG, Twitter, and Article schema — no single point of failure.
+    summary: resolveSummary(story.summary, story.content.plainText),
     content: story.content.markdown,
     virtueDescription: story.virtueDescription,
     audioUrl: story.audioUrl || '',

--- a/src/lib/virtues.ts
+++ b/src/lib/virtues.ts
@@ -29,13 +29,54 @@ const VIRTUES: Virtue[] = (virtuesData as Virtue[])
   .slice()
   .sort((a, b) => a.order - b.order)
 
-/** True when a story's free-text virtue matches this virtue's name or alias. */
-function storyMatchesVirtue(virtue: Virtue, storyVirtue: string): boolean {
+/**
+ * Sub-virtue angle → canon virtue slug.
+ *
+ * `PRODUCT.md` and `writing.md` allow sub-virtues (kindness, mercy, honesty, …)
+ * as story *angles*, but every published story must still map back to one of the
+ * seven canon virtues so no story is orphaned and no virtue hub renders empty.
+ * The CMS `virtue` field stays free-text — it carries the angle shown in the
+ * story eyebrow — and this table is the authoritative bridge from that angle to
+ * canon. It is the engineering counterpart to a `canonicalVirtue` field: the
+ * canon never changes, so (like the seven virtues themselves) it lives in-repo
+ * rather than in the CMS.
+ *
+ * Mappings are sourced from the Writing Vault canon reference (PRO-57):
+ *   - kindness → charity   (compassion freely given)
+ *   - mercy    → charity   (covenant love shown where judgment is expected)
+ *   - honesty  → justice   (giving others the truth they are owed)
+ *
+ * When a new sub-virtue angle is introduced, add it here (see
+ * `content/vault/new-virtue-checklist.md`) rather than leaving an orphan label.
+ */
+const SUB_VIRTUE_TO_CANON_SLUG: Record<string, string> = {
+  kindness: 'charity',
+  mercy: 'charity',
+  honesty: 'justice',
+}
+
+/**
+ * Resolve a story's free-text `virtue` to its canon virtue, or `undefined` when
+ * it maps to no canon entry. Matches a canon title or familiar alternate name
+ * first (e.g. Courage→Fortitude, Love→Charity), then falls back to the
+ * sub-virtue bridge above.
+ */
+function resolveCanonVirtue(storyVirtue: string): Virtue | undefined {
   const needle = storyVirtue.trim().toLowerCase()
-  return (
-    needle === virtue.title.toLowerCase() ||
-    needle === virtue.alternateName?.toLowerCase()
+  const direct = VIRTUES.find(
+    (v) =>
+      needle === v.title.toLowerCase() ||
+      needle === v.alternateName?.toLowerCase(),
   )
+  if (direct) return direct
+
+  const canonSlug = SUB_VIRTUE_TO_CANON_SLUG[needle]
+  return canonSlug ? VIRTUES.find((v) => v.slug === canonSlug) : undefined
+}
+
+/** True when a story's free-text virtue resolves to this canon virtue. */
+function storyMatchesVirtue(virtue: Virtue, storyVirtue: string): boolean {
+  return resolveCanonVirtue(storyVirtue)?.slug === virtue.slug
 }
 
 /** All seven virtues, in canonical order, each with its attached stories. */
@@ -67,8 +108,8 @@ export function getVirtueSlugs(): string[] {
 /**
  * Resolve a story's free-text virtue to its canonical virtue-hub slug, or null
  * when it maps to no canon entry. Lets a story link back up to its virtue page
- * using the same name/alias matching the virtue pages use to gather stories.
+ * using the same resolution the virtue pages use to gather stories.
  */
 export function getVirtueSlugForStoryVirtue(storyVirtue: string): string | null {
-  return VIRTUES.find((v) => storyMatchesVirtue(v, storyVirtue))?.slug ?? null
+  return resolveCanonVirtue(storyVirtue)?.slug ?? null
 }

--- a/writing.md
+++ b/writing.md
@@ -23,6 +23,19 @@ Good Classical Virtues prose is:
 - moral without scolding;
 - calm, exact, and unhurried.
 
+Ban these drift patterns in first drafts and final edits:
+
+- modern motivational phrasing such as "unlock your potential," "choose your
+  best self," "embrace the journey," or "live with purpose";
+- civilizational or TED-talk openings such as "in a world where," "today more
+  than ever," "modern seekers," or "the timeless lesson we all need";
+- promotional, devotional, or inspirational cadence that sounds like a poster
+  instead of a tale;
+- polished moral triads used as padding, especially three abstract nouns in a
+  row;
+- symbolic explanations that tell the reader what the image means after the
+  narrative has already shown it.
+
 ## Story Shape
 
 Story pages use a consistent anthology structure:
@@ -39,6 +52,14 @@ related-reading paragraphs, or duplicate moral cards inside the body.
 Use `virtueDescription` for the moral/reflection that appears in the rendered
 moral card. If the body already contains a moral heading, the page will feel
 duplicated and should be revised before publication.
+
+The first paragraph must put an actor in a concrete setting with visible moral
+pressure by the end of the paragraph. Weather, landscape, and atmosphere may
+serve the action, but they may not delay the problem.
+
+Most stories should run 350-650 words. Shorter fables may be tighter; longer
+retellings need a reason in the brief, such as necessary source context,
+dialogue that clarifies the choice, or a second scene required by the original.
 
 ## Field Contract
 
@@ -60,6 +81,10 @@ If the current CMS schema does not expose one of these fields yet, preserve the
 intent in the brief or publish notes and route schema/rendering work to
 engineering.
 
+The `content` field may contain only the story narrative. Do not place
+separators, `***`, related links, FAQ copy, source notes, metadata notes, or a
+second moral ending inside it.
+
 ## Canon And Sub-Virtues
 
 The product canon is the seven classical virtues named in `@PRODUCT.md`.
@@ -69,6 +94,35 @@ used as story angles, but they must map back to the canon before publication.
 Do not create orphan virtue labels that make canonical virtue pages look empty.
 If a story uses a sub-virtue, the brief must name the canonical virtue it
 supports and the reason for that mapping.
+
+Name the virtue only after the action has made it visible. In the story body,
+the default is one named virtue moment at or after the decisive choice. Repeated
+labels such as honest, honesty, truthful, sincere, and true-hearted in the same
+short scene should be cut unless each word does distinct narrative work.
+
+Every brief and catalog record must name one canonical virtue from the seven and
+may add one sub-virtue angle. The sub-virtue is an editorial angle, not the page
+taxonomy.
+
+## Sentence Rhythm And Diction
+
+Read the draft aloud before it moves to review. Classical Virtues prose should
+sound like a parent telling a well-made story, not like an introduction, sermon,
+or marketing page.
+
+Use this rhythm standard:
+
+- keep the usual sentence plain and sequential: setup, action, fear or cost,
+  consequence;
+- vary sentence length, but avoid three consecutive sentences with the same
+  long, balanced, polished shape;
+- let short sentences carry fear, decision, and consequence;
+- use concrete nouns and verbs before adjectives and adverbs;
+- cut stacked modifiers unless a detail clarifies the scene.
+
+As a practical edit, mark every adjective and adverb in a paragraph that feels
+ornamental. Keep the one concrete modifier that helps the child picture the
+moment; remove the rest.
 
 ## SEO Boundary
 
@@ -96,6 +150,28 @@ Quinn may recommend terms, metadata, and search intent. Margaret decides how
 that guidance enters the published content, and Quill must keep the story voice
 intact.
 
+Search guidance belongs in structured surfaces, not in the tale. If a keyword
+cannot enter the title, slug, summary, metadata, source note, image alt text, or
+internal-link recommendation without sounding forced, leave it out.
+
+## Vault Comparison Gate
+
+Before publication, compare every draft against at least two locked exemplars in
+`content/vault/exemplars/`. This gate is mandatory.
+
+The review note must name the two exemplars used and record:
+
+- how the opening matches or departs from the exemplar pattern;
+- whether the decisive virtue is shown before it is named;
+- whether sentence rhythm stays read-aloud plain;
+- whether the ending trusts an image or action instead of explaining the symbol;
+- whether `content` contains narrative only;
+- whether the canonical virtue and any sub-virtue angle are mapped cleanly.
+
+Use `content/vault/drift-diagnosis.md` as the current list of known failure
+patterns. A draft that repeats a diagnosed drift pattern must be revised before
+publish.
+
 ## Approval Checklist
 
 Before a story is published, Margaret should confirm:
@@ -108,7 +184,7 @@ Before a story is published, Margaret should confirm:
 - the story maps to the seven-virtue canon;
 - source/provenance is accurate or uncertainty is cut;
 - image alt text is meaningful;
-- the draft has been compared against approved live examples for tone.
+- the draft has passed the two-exemplar vault comparison gate.
 
-Approved comparison examples should include at least two live stories whose
-structure and voice still match the target anthology standard.
+The two comparison examples should come from the locked vault unless Margaret
+explicitly approves a newer live story as an added reference.


### PR DESCRIPTION
Consolidates all PRO-56 child work (writing hardening + Vault, SEO contract + technical hardening, catalog/canon consistency) into one branch for review and merge.

## What's included
- **A1/A2 — Writing Vault + voice hardening** (`content/vault/`, `content/production-recipe.md`, `writing.md`): three locked gold-standard exemplars with annotations, measured drift diagnosis, banned drift-pattern list, sentence-rhythm rules, scene-first opening rule, and a mandatory two-exemplar comparison gate before publish.
- **B1/B2 — SEO contract + technical hardening** (`SEO.md`, render/metadata code): allowed-vs-forbidden SEO surfaces; summary fallback chain, virtue→slug validation, OG-text overflow guard, imageAlt presence — none touching the story body.
- **C1 — Catalog consistency** (canon remap, `content/vault/catalog-audit.md`, `content/vault/new-virtue-checklist.md`): sub-virtue labels mapped to the seven canon virtues + turnkey "new virtue" checklist.
- **PRO-62 — `source` provenance field** wired end-to-end with regenerated basehub types.

## Commits
- PRO-57/PRO-59: Writing Vault + writing.md/production recipe
- PRO-58: SEO contract
- PRO-60: SEO technical hardening
- PRO-61: catalog audit + canon mapping + new-virtue checklist
- PRO-62: source provenance field

Closes PRO-56, PRO-57, PRO-58, PRO-59, PRO-60, PRO-61, PRO-62.

🤖 Generated with [Claude Code](https://claude.com/claude-code)