### PR TITLE
Review and tighten site chrome copy

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
   title: 'About',
-  description: 'Why virtue, and why stories? Learn how Classical Virtues uses timeless narratives to cultivate character, wisdom, and moral imagination.',
+  description: 'Why virtue, and why stories? Classical Virtues gathers short classical tales for character, wisdom, and moral imagination.',
   alternates: {
     canonical: '/about',
   },

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,7 +14,7 @@ export const metadata: Metadata = {
     default: "Classical Virtues | Timeless Stories of Character",
     template: "%s | Classical Virtues"
   },
-  description: "Discover timeless virtues through classical stories. Our collection of moral tales teaches enduring values of character, ethics, and wisdom for modern times.",
+  description: "Read classical virtue stories gathered for families: short moral tales with plain summaries, full text, and narrated audio.",
   applicationName: "Classical Virtues",
   keywords: [
     "virtues",
@@ -37,18 +37,18 @@ export const metadata: Metadata = {
     url: "https://classicalvirtues.com",
     siteName: "Classical Virtues",
     title: "Classical Virtues | Timeless Stories of Character",
-    description: "Discover timeless virtues through classical stories. Our collection of moral tales teaches enduring values of character, ethics, and wisdom for modern times.",
+    description: "Read classical virtue stories gathered for families: short moral tales with plain summaries, full text, and narrated audio.",
     images: [{
       url: "/api/og",
       width: 1200,
       height: 630,
-      alt: "Classical Virtues - Timeless Stories of Character"
+      alt: "Classical Virtues: Timeless Stories of Character"
     }]
   },
   twitter: {
     card: "summary_large_image",
     title: "Classical Virtues | Timeless Stories of Character",
-    description: "Discover timeless virtues through classical stories. Our collection of moral tales teaches enduring values of character, ethics, and wisdom for modern times.",
+    description: "Read classical virtue stories gathered for families: short moral tales with plain summaries, full text, and narrated audio.",
     images: ["/api/og"],
     creator: "@classicalvirtues"
   },
@@ -95,7 +95,7 @@ const websiteSchema = {
   "@id": "https://classicalvirtues.com/#website",
   "name": "Classical Virtues",
   "url": "https://classicalvirtues.com",
-  "description": "Discover timeless virtues through classical stories. Our collection of moral tales teaches enduring values of character, ethics, and wisdom for modern times.",
+  "description": "Read classical virtue stories gathered for families: short moral tales with plain summaries, full text, and narrated audio.",
   "inLanguage": "en",
   "publisher": {
     "@id": "https://classicalvirtues.com/#organization"

--- a/src/app/stories/[slug]/page.tsx
+++ b/src/app/stories/[slug]/page.tsx
@@ -113,7 +113,7 @@ export default async function Post({ params }: { params: Params }) {
     // page rendering (plain-text virtue) per the graceful-degradation principle.
     console.error(
       `[virtue-mapping] Story "${story.slug}" has virtue "${story.virtue}" which maps to no canon entry. ` +
-        `The virtue-hub link will be missing — set the story virtue to a canon name or alias (see src/data/virtues.json).`,
+        `The virtue-hub link will be missing. Set the story virtue to a canon name or alias (see src/data/virtues.json).`,
     );
   }
   const storyContent = await renderStoryContent(story.content);

--- a/src/app/virtues/[slug]/page.tsx
+++ b/src/app/virtues/[slug]/page.tsx
@@ -105,7 +105,7 @@ export default async function VirtuePage({ params }: { params: Params }) {
         </h2>
         {virtue.stories.length === 0 ? (
           <p className="mt-4 text-muted-foreground">
-            No stories have been gathered here yet — they are being prepared.{' '}
+            No stories have been gathered here yet. They are being prepared.{' '}
             <Link href="/stories" className="underline underline-offset-4 hover:text-foreground">
               Browse the whole collection
             </Link>

--- a/src/app/virtues/page.tsx
+++ b/src/app/virtues/page.tsx
@@ -6,7 +6,7 @@ import type { Metadata } from 'next'
 export const metadata: Metadata = {
   title: 'The Virtues',
   description:
-    'The seven classical virtues — Prudence, Justice, Fortitude, Temperance, Faith, Hope, and Charity — each a home for the stories that teach it.',
+    'The seven classical virtues: Prudence, Justice, Fortitude, Temperance, Faith, Hope, and Charity. Each one gathers the stories that teach it.',
   alternates: {
     canonical: '/virtues',
   },
@@ -32,7 +32,7 @@ export default async function VirtuesIndex() {
       <header className="mb-8 space-y-3 sm:mb-10">
         <h1 className="font-heading text-4xl sm:text-5xl">The Virtues</h1>
         <p className="max-w-2xl text-muted-foreground">
-          The seven classical virtues that order this collection — four cardinal
+          The seven classical virtues that order this collection: four cardinal
           and three theological. Each one gathers the stories that teach it.
         </p>
       </header>

--- a/src/components/ShareStory.tsx
+++ b/src/components/ShareStory.tsx
@@ -7,7 +7,7 @@ type ShareState = 'idle' | 'copied';
 /**
  * A restrained share affordance for story pages. On devices with the native
  * share sheet (mostly mobile) it opens that; everywhere else it copies the
- * link and quietly confirms. No counts, no logos, no "share to X" — just a
+ * link and quietly confirms. No counts, no logos, no "share to X": just a
  * way to pass a story along.
  */
 export default function ShareStory({ title, slug }: { title: string; slug: string }) {
@@ -25,7 +25,7 @@ export default function ShareStory({ title, slug }: { title: string; slug: strin
   async function handleShare() {
     if (typeof navigator !== 'undefined' && typeof navigator.share === 'function') {
       try {
-        await navigator.share({ title, text: `“${title}” — a story from Classical Virtues`, url });
+        await navigator.share({ title, text: `“${title}”: a story from Classical Virtues`, url });
         return;
       } catch {
         // The reader dismissed the sheet, or it failed. Fall through to copy.

--- a/src/data/virtues.json
+++ b/src/data/virtues.json
@@ -4,14 +4,14 @@
     "title": "Prudence",
     "order": 1,
     "tagline": "The wisdom to choose well.",
-    "description": "Prudence is the quiet art of seeing clearly before we act — weighing what is true, what is kind, and what is wise, then choosing the better path. It is the virtue that quietly guides all the others, the steady voice that asks, “What is the right thing to do, and how shall I do it well?” In these stories, prudence looks like patience, good judgment, and the courage to think before we leap."
+    "description": "Prudence is the quiet art of seeing clearly before we act: weighing what is true, what is kind, and what is wise, then choosing the better path. It is the virtue that quietly guides all the others, the steady voice that asks, “What is the right thing to do, and how shall I do it well?” In these stories, prudence looks like patience, good judgment, and the courage to think before we leap."
   },
   {
     "slug": "justice",
     "title": "Justice",
     "order": 2,
     "tagline": "Giving each their due.",
-    "description": "Justice is the habit of treating others fairly and giving each person what they are owed — honesty, respect, and a fair share. It asks us to keep our promises, to make right what we have wronged, and to stand up for those who cannot stand for themselves. The stories gathered here show justice as something warm and human: the keeping of one’s word, the mending of a quarrel, the small acts of fairness that hold a family together."
+    "description": "Justice is the habit of treating others fairly and giving each person what they are owed: honesty, respect, and a fair share. It asks us to keep our promises, to make right what we have wronged, and to stand up for those who cannot stand for themselves. The stories gathered here show justice as something warm and human: the keeping of one’s word, the mending of a quarrel, the small acts of fairness that hold a family together."
   },
   {
     "slug": "fortitude",
@@ -19,21 +19,21 @@
     "alternateName": "Courage",
     "order": 3,
     "tagline": "Standing firm when it is hard.",
-    "description": "Fortitude — the virtue we more often call courage — is the strength to do what is right even when it is difficult or frightening. It is not the absence of fear but the steadiness to act in spite of it: to endure hardship, to face danger for a good cause, and to hold fast to what is true. In these tales courage wears many faces, the bold and the quiet alike, but always it means standing firm when standing firm is hard."
+    "description": "Fortitude, the virtue we more often call courage, is the strength to do what is right even when it is difficult or frightening. It is not the absence of fear but the steadiness to act in spite of it: to endure hardship, to face danger for a good cause, and to hold fast to what is true. In these tales courage wears many faces, the bold and the quiet alike, but always it means standing firm when standing firm is hard."
   },
   {
     "slug": "temperance",
     "title": "Temperance",
     "order": 4,
     "tagline": "Moderation and gentle self-mastery.",
-    "description": "Temperance is the gift of self-mastery — knowing when enough is enough, and choosing balance over excess. It teaches us to govern our appetites and our tempers, to enjoy good things without being ruled by them, and to find the calm that comes from a well-ordered heart. The stories here show temperance as a quiet kind of freedom: the patience to wait, the grace to share, and the wisdom to keep ourselves in gentle check."
+    "description": "Temperance is the gift of self-mastery: knowing when enough is enough, and choosing balance over excess. It teaches us to govern our appetites and our tempers, to enjoy good things without being ruled by them, and to find the calm that comes from a well-ordered heart. The stories here show temperance as a quiet kind of freedom: the patience to wait, the grace to share, and the wisdom to keep ourselves in gentle check."
   },
   {
     "slug": "faith",
     "title": "Faith",
     "order": 5,
     "tagline": "Trust that holds fast.",
-    "description": "Faith is trust — in what is good, in one another, and in the promises we hold dear. It is the quiet confidence that carries us through uncertainty, the belief that keeps us steadfast when we cannot yet see the way. In these stories faith appears as loyalty kept, trust honored, and hearts that hold fast to hope even in the dark."
+    "description": "Faith is trust: in what is good, in one another, and in the promises we hold dear. It is the quiet confidence that carries us through uncertainty, the belief that keeps us steadfast when we cannot yet see the way. In these stories faith appears as loyalty kept, trust honored, and hearts that hold fast to hope even in the dark."
   },
   {
     "slug": "hope",
@@ -48,6 +48,6 @@
     "alternateName": "Love",
     "order": 7,
     "tagline": "Love that gives without counting the cost.",
-    "description": "Charity — the love that gives freely — is the greatest of the virtues and the warm heart of all the rest. It is kindness without keeping score, compassion for the stranger, and the willingness to put another’s good before our own. In these stories charity looks like an open hand and an open door: mercy shown, burdens shared, and love offered without counting the cost."
+    "description": "Charity, the love that gives freely, is the greatest of the virtues and the warm heart of all the rest. It is kindness without keeping score, compassion for the stranger, and the willingness to put another’s good before our own. In these stories charity looks like an open hand and an open door: mercy shown, burdens shared, and love offered without counting the cost."
   }
 ]

--- a/src/lib/basehub.ts
+++ b/src/lib/basehub.ts
@@ -48,7 +48,7 @@ function buildItemSelection(withSource: boolean): StoriesItemGenqlSelection {
 // retries with the base selection if Basehub rejects it (i.e. the field has
 // not been added to the schema yet). This keeps the catalog rendering whether
 // or not `source` exists, and makes provenance self-activating once the field
-// lands — no second deploy required.
+// lands, with no second deploy required.
 export async function getAllStories(): Promise<Story[]> {
   try {
     let data

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -4,13 +4,13 @@
  * These keep the metadata / OpenGraph / structured-data path resilient: a
  * missing CMS field (summary, image alt) or an over-long string (OG overlay
  * text) degrades gracefully instead of producing an empty meta description or a
- * broken share image. None of these touch the story body or prose — they only
+ * broken share image. None of these touch the story body or prose. They only
  * harden the technical SEO surfaces named in the SEO contract (`SEO.md`).
  */
 
 /** Brand-safe default used when a story has no usable summary at all. */
 export const DEFAULT_SUMMARY =
-  'A short story from the Classical Virtues anthology — a timeless tale that teaches a virtue through character and choice.'
+  'A short story from the Classical Virtues anthology, teaching virtue through character and choice.'
 
 /**
  * Collapse whitespace and trim a string into a single clean line, or '' when

--- a/src/lib/stories.ts
+++ b/src/lib/stories.ts
@@ -42,7 +42,7 @@ function basehubToStory(story: Story): StoryData | null {
     // Always populated: concrete CMS alt, else a descriptive fallback.
     imageAlt: resolveImageAlt(story.image.alt, story._title),
     // Always populated: editorial summary, else prose excerpt, else brand default.
-    // Feeds meta description, OG, Twitter, and Article schema — no single point of failure.
+    // Feeds meta description, OG, Twitter, and Article schema with no single point of failure.
     summary: resolveSummary(story.summary, story.content.plainText),
     content: story.content.markdown,
     virtueDescription: story.virtueDescription,

--- a/src/lib/virtues.ts
+++ b/src/lib/virtues.ts
@@ -2,12 +2,12 @@ import virtuesData from '@/data/virtues.json'
 import { getAllStories, type StoryData } from './stories'
 
 /**
- * The seven classical virtues — the fixed canon (four cardinal, three
+ * The seven classical virtues: the fixed canon (four cardinal, three
  * theological). The descriptions are warm, family-anthology copy.
  *
  * This is the source of truth for the canon and is mirrored into Basehub by
  * `scripts/seed-virtues.mjs`. Because the canon never changes, it lives in the
- * repo so the site renders all seven regardless of CMS availability — the same
+ * repo so the site renders all seven regardless of CMS availability. The same
  * graceful-degradation principle used for stories in `src/lib/stories.ts`.
  */
 export interface Virtue {
@@ -35,8 +35,8 @@ const VIRTUES: Virtue[] = (virtuesData as Virtue[])
  * `PRODUCT.md` and `writing.md` allow sub-virtues (kindness, mercy, honesty, …)
  * as story *angles*, but every published story must still map back to one of the
  * seven canon virtues so no story is orphaned and no virtue hub renders empty.
- * The CMS `virtue` field stays free-text — it carries the angle shown in the
- * story eyebrow — and this table is the authoritative bridge from that angle to
+ * The CMS `virtue` field stays free-text. It carries the angle shown in the
+ * story eyebrow, and this table is the authoritative bridge from that angle to
  * canon. It is the engineering counterpart to a `canonicalVirtue` field: the
  * canon never changes, so (like the seven virtues themselves) it lives in-repo
  * rather than in the CMS.


### PR DESCRIPTION
## Summary
- tightened global/about metadata so it reads like family anthology copy rather than generic moral-education copy
- removed all em dashes from `src/`, including virtue page copy, share text, fallback SEO copy, virtue data descriptions, and comments covered by the literal sweep
- kept edits to chrome/metadata/data copy only; no Basehub story prose, titles, or summaries changed

## Changed strings
- Global metadata: `Discover timeless virtues through classical stories...` -> `Read classical virtue stories gathered for families...`
- OG alt: `Classical Virtues - Timeless Stories of Character` -> `Classical Virtues: Timeless Stories of Character`
- About metadata: `Learn how Classical Virtues uses timeless narratives...` -> `Classical Virtues gathers short classical tales...`
- Virtues metadata: `The seven classical virtues — ... — each a home...` -> `The seven classical virtues: ... Each one gathers...`
- Virtues page intro: `...collection — four cardinal...` -> `...collection: four cardinal...`
- Empty virtue state: `No stories have been gathered here yet — they are being prepared.` -> `No stories have been gathered here yet. They are being prepared.`
- Share text: `“{title}” — a story from Classical Virtues` -> `“{title}”: a story from Classical Virtues`
- Default story summary: `A short story from the Classical Virtues anthology — a timeless tale...` -> `A short story from the Classical Virtues anthology, teaching virtue...`
- Virtue descriptions: replaced em-dash constructions in Prudence, Justice, Fortitude, Temperance, Faith, and Charity with colons or commas.
- Developer comments/log strings: replaced em dashes in `src/lib/*` and virtue mapping warning so `rg "—" src` is clean.

## Verification
- `rg -n "—" src` returns no matches
- `rg -n "dive into|unlock|elevate|seamless|journey|in today's world|testament to|rich tapestry|today more than ever|modern seekers|in a world where|embrace the journey|live with purpose|utilize" src` returns no matches
- `pnpm run lint`
