### PR TITLE
PRO-77: Add Umami analytics script to site

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata, Viewport } from "next";
+import Script from "next/script";
 import { Analytics } from "@vercel/analytics/next"
 import { cn } from '@/lib/utils'
 import ErrorBoundary from '@/components/ErrorBoundary'
@@ -129,6 +130,16 @@ export default function RootLayout({
         </main>
         <Footer />
         <Analytics />
+        {/* Umami analytics — self-hosted, public website-id (no secret).
+            Skipped in local dev (NODE_ENV !== 'production') to avoid polluting
+            traffic data; loads on production and preview builds. */}
+        {process.env.NODE_ENV === 'production' && (
+          <Script
+            src="https://analytics.dudesdesign.com/script.js"
+            data-website-id="3ec4b765-4eef-445d-89d8-db485a2eeba5"
+            strategy="afterInteractive"
+          />
+        )}
         <JsonLd data={websiteSchema} />
         <JsonLd data={organizationSchema} />
       </body>


### PR DESCRIPTION
## Summary
Installs self-hosted Umami analytics across the whole site by adding the tracking script to the root App Router layout (`src/app/layout.tsx`), so it covers every route (home, virtue hubs, story pages).

- Loaded via `next/script` with `strategy="afterInteractive"`, matching how the app loads other third-party scripts (e.g. Vercel `Analytics`) rather than a raw `<script>` tag.
- `data-website-id` is exactly `3ec4b765-4eef-445d-89d8-db485a2eeba5`; `src` is `https://analytics.dudesdesign.com/script.js`.
- **Production-only gate:** rendered only when `process.env.NODE_ENV === 'production'`, so it loads on production and preview builds but is skipped in local `pnpm run dev`. This avoids polluting traffic data with dev sessions. The website-id is public client-side, so no env var/secret is required.
- Engineering only — no editorial/content changes.

## Verification
- `pnpm run lint` passes.
- `pnpm run build` succeeds (17/17 static pages).
- The script `src`, `data-website-id`, and `afterInteractive` strategy appear in the generated HTML for home, `/about`, `/virtues`, and `/stories` (injected client-side by `next/script` after hydration). Coverage of all routes comes from placement in the root layout.

Closes PRO-77.

🤖 Generated with [Claude Code](https://claude.com/claude-code)