### PR TITLE
PRO-82: Remove reader-facing "Source:" line below stories

### DIFF
--- a/src/app/stories/[slug]/page.tsx
+++ b/src/app/stories/[slug]/page.tsx
@@ -146,9 +146,6 @@ export default async function Post({ params }: { params: Params }) {
     },
     "articleSection": "Moral Stories",
     "keywords": [story.virtue, "virtue", "moral story", "classical virtues"],
-    // Provenance as structured data (allowed SEO surface): the public-domain or
-    // classical source this retelling is based on.
-    ...(story.source ? { "isBasedOn": story.source } : {}),
     ...(story.audioUrl
       ? {
           "audio": {
@@ -196,13 +193,6 @@ export default async function Post({ params }: { params: Params }) {
       <div className="prose prose-lg">
         {storyContent}
       </div>
-      {story.source && (
-        // Provenance line: a quiet, structured attribution kept outside the
-        // narrative body and the moral card (SEO boundary, writing.md).
-        <p className="mt-6 text-sm italic text-muted-foreground">
-          Source: {story.source}
-        </p>
-      )}
       <Card className="bg-accent text-accent-foreground mt-8">
         <CardContent className="p-8">
           <div className="space-y-6">

--- a/src/lib/basehub.ts
+++ b/src/lib/basehub.ts
@@ -1,14 +1,9 @@
 import { basehub } from 'basehub'
-import type { StoriesItem, StoriesItemGenqlSelection } from '../../basehub-types'
+import type { StoriesItem } from '../../basehub-types'
 import '../../basehub.config' // Import the config to ensure it's loaded
 
-// Use BaseHub's generated types for full type safety. `source` (provenance
-// note, PRO-62) is an additive Basehub field: it does not appear on the
-// generated `StoriesItem` type until the field is created in the Basehub
-// dashboard and `pnpm run basehub` regenerates `basehub-types.d.ts`. We model
-// it as an optional extension here so the reader/render layer can consume it
-// immediately, and select it defensively (see `buildItemSelection`).
-export type Story = StoriesItem & { source?: string | null }
+// Use BaseHub's generated types for full type safety.
+export type Story = StoriesItem
 
 // Base field selection shared by both story queries.
 const STORY_ITEM_FIELDS = {
@@ -30,35 +25,10 @@ const STORY_ITEM_FIELDS = {
   },
 }
 
-/**
- * Build the story field selection, optionally including the additive `source`
- * provenance field. The cast is required because `source` is not yet part of
- * the generated genql types; it is removed automatically (no code change) once
- * the field exists in the schema and types are regenerated.
- */
-function buildItemSelection(withSource: boolean): StoriesItemGenqlSelection {
-  const selection = withSource
-    ? { ...STORY_ITEM_FIELDS, source: true }
-    : { ...STORY_ITEM_FIELDS }
-  return selection as StoriesItemGenqlSelection
-}
-
 // Fetch all stories with proper BaseHub caching.
-// The query first selects the `source` provenance field and transparently
-// retries with the base selection if Basehub rejects it (i.e. the field has
-// not been added to the schema yet). This keeps the catalog rendering whether
-// or not `source` exists, and makes provenance self-activating once the field
-// lands, with no second deploy required.
 export async function getAllStories(): Promise<Story[]> {
   try {
-    let data
-    try {
-      data = await basehub().query({ stories: { items: buildItemSelection(true) } })
-    } catch {
-      // `source` may not be in the Basehub schema yet (PRO-62).
-      data = await basehub().query({ stories: { items: buildItemSelection(false) } })
-    }
-
+    const data = await basehub().query({ stories: { items: STORY_ITEM_FIELDS } })
     return data.stories.items as Story[]
   } catch (error) {
     console.error('Error fetching stories from Basehub:', error)
@@ -66,17 +36,10 @@ export async function getAllStories(): Promise<Story[]> {
   }
 }
 
-// Fetch a single story by slug with proper BaseHub caching (same `source`
-// fallback as getAllStories above).
+// Fetch a single story by slug with proper BaseHub caching.
 export async function getStoryBySlug(slug: string): Promise<Story | null> {
   try {
-    const args = { first: 100 }
-    let data
-    try {
-      data = await basehub().query({ stories: { __args: args, items: buildItemSelection(true) } })
-    } catch {
-      data = await basehub().query({ stories: { __args: args, items: buildItemSelection(false) } })
-    }
+    const data = await basehub().query({ stories: { __args: { first: 100 }, items: STORY_ITEM_FIELDS } })
 
     // Find the story with matching slug
     const story = data.stories.items.find((item: Pick<Story, '_slug'>) => item._slug === slug)

--- a/src/lib/stories.ts
+++ b/src/lib/stories.ts
@@ -13,13 +13,6 @@ export interface StoryData {
   summary: string
   content: string
   virtueDescription: string
-  /**
-   * Public-domain / classical source note (e.g. "From Aesop's Fables").
-   * Optional: rendered as a small provenance line outside the story body when
-   * present, omitted entirely otherwise. Lives in a structured field, never in
-   * the narrative `content`, per the SEO boundary in `writing.md`.
-   */
-  source?: string
   audioUrl: string
   wordCount: number
 }
@@ -46,9 +39,6 @@ function basehubToStory(story: Story): StoryData | null {
     summary: resolveSummary(story.summary, story.content.plainText),
     content: story.content.markdown,
     virtueDescription: story.virtueDescription,
-    // Optional provenance note; omit when empty so nothing renders. `source`
-    // is an additive Basehub field (PRO-62) and may be absent on older items.
-    source: story.source?.trim() || undefined,
     audioUrl: story.audioUrl || '',
     wordCount: story.content.plainText.split(/\s+/).length,
   }


### PR DESCRIPTION
## What

Removes the reader-facing `Source:` attribution surface introduced by PRO-62 (commit `277b370`). Per the board directive in PRO-81, story source/provenance must never surface to readers or search.

## Changes

- **`src/app/stories/[slug]/page.tsx`** — removed the visible `Source:` paragraph below story prose, and removed the `isBasedOn` entry from the Article JSON-LD structured data.
- **`src/lib/stories.ts`** — removed `StoryData.source` and its conversion (no remaining consumers).
- **`src/lib/basehub.ts`** — removed the `source` query/fallback machinery (`buildItemSelection`, the `Story` type extension, the try/retry blocks); both queries are back to a single plain field selection. No dead code left behind.

The Basehub `source` schema field (editorial metadata in Margaret's content layer) is **untouched** — only the code that consumed and rendered it is removed.

## Editorial check

The removed code cited "SEO boundary, writing.md". Confirmed `writing.md` treats `source` only as a structured editorial metadata field ("source note where applicable") and explicitly forbids source notes in reader content — it does **not** mandate a reader-facing line or structured-data surface. No editorial conflict; removal is the correct default per PRO-81.

## Acceptance criteria

- [x] Visible `Source:` paragraph no longer renders on story pages
- [x] `source` removed from JSON-LD structured data
- [x] Backend plumbing removed (no remaining consumer → no dead code)
- [x] No story prose / titles / summaries / moral reflections touched
- [x] `pnpm run lint` passes; `tsc --noEmit` clean; zero residual `source` references in `src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)