### PR TITLE
PRO-73: enforce no-em-dash punctuation rule in writing standard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,11 @@ affects the public reading experience:
   new sub-virtue angle requires one line in `SUB_VIRTUE_TO_CANON_SLUG`
   (`src/lib/virtues.ts`); see also `content/vault/catalog-audit.md`.
 
+Story prose (title, summary, body, and `virtueDescription`) must contain no em or
+en dashes (`—`, `–`); they read as a machine-writing tell. Recast with standard
+punctuation and verify with `grep -nP "—|–"` before publish. See the punctuation
+rule in `@writing.md`.
+
 Engineering work must preserve approved editorial content unless the task
 explicitly asks for editorial changes. Do not rewrite story prose, titles,
 summaries, or moral reflections while fixing code, scripts, schema adapters, or

--- a/content/vault/drift-diagnosis.md
+++ b/content/vault/drift-diagnosis.md
@@ -127,6 +127,21 @@ Fix for A2 and C1: every brief and catalog record must name a canonical virtue f
 
 Fix for A2/C1: reinforce that the story body is narrative only, and metadata/search work belongs in structured fields: summary, metadata, alt text, source note, and internal-link recommendations.
 
+### 9. Em Dashes Used As Connective Punctuation
+
+Recent and legacy stories lean on em dashes (`—`) for asides, dramatic pauses, and
+appositive clauses. `The Boy and the Filberts` used five in the body; the three
+locked originals each carried one. The dash reads as a machine-writing tell and
+flattens read-aloud cadence, and until 2026-06-21 no rule in `writing.md` named
+it, so every drafter reproduced the exemplars faithfully.
+
+Fix: ban em and en dashes (`—`, `–`) in story prose. Recast with a comma, period,
+colon, semicolon, or parentheses; a sentence that "needs" a dash usually wants to
+be two sentences. The straight hyphen in compound words is fine. Verify with
+`grep -nP "—|–"` over title, summary, body, and `virtueDescription` before
+publish. The locked exemplars were corrected on 2026-06-21 so the comparison gate
+no longer models the pattern.
+
 ## Story-by-Story Notes
 
 ### The Woodcutter's Axe
@@ -205,4 +220,5 @@ The writing-guide hardening should add:
 - a body-boundary rule: no separators, related links, FAQ/SEO copy, or second moral endings inside `content`;
 - a length rule: default 350-650 words unless the brief approves a longer treatment;
 - a canon rule: canonical virtue plus optional sub-virtue angle on every brief and record;
-- a read-aloud check: cut any sentence that sounds like promotional, devotional, or motivational copy rather than story.
+- a read-aloud check: cut any sentence that sounds like promotional, devotional, or motivational copy rather than story;
+- a punctuation rule: no em or en dashes (`—`, `–`) in story prose; recast with standard punctuation and verify with a dash grep before publish.

--- a/content/vault/exemplars/androcles-and-the-lion.md
+++ b/content/vault/exemplars/androcles-and-the-lion.md
@@ -7,7 +7,7 @@
 - Slug: `androcles-and-the-lion`
 - Stored virtue label: `Kindness`
 - Canon mapping for future use: `Charity` angle, because the central act is compassion freely given to a suffering creature, returned in loyal love.
-- Summary: Discover the timeless tale of Androcles and the Lion—a story of compassion, courage, and unexpected friendship in ancient Rome. Learn how a simple act of kindness changed two lives forever in this inspiring fable about empathy and the rewards of true loyalty.
+- Summary: Discover the timeless tale of Androcles and the Lion, a story of compassion, courage, and unexpected friendship in ancient Rome. Learn how a simple act of kindness changed two lives forever in this inspiring fable about empathy and the rewards of true loyalty.
 - Virtue reflection: Kindness, even in the smallest acts, can forge unbreakable bonds. When we show compassion, it can return to us in unexpected and powerful ways.
 - Image alt: 
 - Audio URL present: yes

--- a/content/vault/exemplars/david-and-mephibosheth.md
+++ b/content/vault/exemplars/david-and-mephibosheth.md
@@ -16,7 +16,7 @@
 
 ## Locked Story Body
 
-Years had passed since David had become king of Israel, and his rule was marked by the justice and mercy that had guided him since his youth. Though he was now a powerful king, David had not forgotten his dear friend Jonathan, son of Saul, Israel’s former king. Jonathan had been more than a friend; he was a brother in spirit, standing by David’s side despite his father’s bitter jealousy and attempts to kill David. Jonathan’s loyalty and courage had saved David’s life on more than one occasion, and even after Jonathan’s death in battle, David’s heart held a sacred promise he had made to him—to show kindness to his family, no matter the cost.
+Years had passed since David had become king of Israel, and his rule was marked by the justice and mercy that had guided him since his youth. Though he was now a powerful king, David had not forgotten his dear friend Jonathan, son of Saul, Israel’s former king. Jonathan had been more than a friend; he was a brother in spirit, standing by David’s side despite his father’s bitter jealousy and attempts to kill David. Jonathan’s loyalty and courage had saved David’s life on more than one occasion, and even after Jonathan’s death in battle, David’s heart held a sacred promise he had made to him: to show kindness to his family, no matter the cost.
 
 One day, moved by this memory, David asked aloud in his palace, “Is there anyone left in the house of Saul to whom I can show kindness for Jonathan’s sake?” His words surprised those around him, for the custom was for kings to eliminate the families of their rivals, securing the throne. But David, ever faithful to his promises, chose a different path.
 

--- a/content/vault/exemplars/the-cherry-tree.md
+++ b/content/vault/exemplars/the-cherry-tree.md
@@ -28,7 +28,7 @@ He took a deep breath, met his father’s gaze, and said, “Father, I cannot te
 
 For a moment, the air seemed heavy. Augustine Washington’s face softened. He put a hand on his son’s shoulder, nodding slowly. “My son, your honesty means more to me than a thousand cherry trees. You’ve shown great courage in telling the truth, and that is something I will always be proud of.”
 
-Though George had damaged the tree, he had done something far more valuable that day—he upheld his character. And in that moment, George learned that a man’s word, when given in truth, was worth more than anything material.
+Though George had damaged the tree, he had done something far more valuable that day. He upheld his character. And in that moment, George learned that a man’s word, when given in truth, was worth more than anything material.
 
 ## Editorial Annotation
 

--- a/writing.md
+++ b/writing.md
@@ -34,7 +34,10 @@ Ban these drift patterns in first drafts and final edits:
 - polished moral triads used as padding, especially three abstract nouns in a
   row;
 - symbolic explanations that tell the reader what the image means after the
-  narrative has already shown it.
+  narrative has already shown it;
+- em dashes and en dashes (`—`, `–`) used as connective, parenthetical, or
+  dramatic punctuation. This is a common machine-writing tell and must be recast
+  with standard punctuation before publication.
 
 ## Story Shape
 
@@ -118,11 +121,21 @@ Use this rhythm standard:
   long, balanced, polished shape;
 - let short sentences carry fear, decision, and consequence;
 - use concrete nouns and verbs before adjectives and adverbs;
-- cut stacked modifiers unless a detail clarifies the scene.
+- cut stacked modifiers unless a detail clarifies the scene;
+- do not use em dashes or en dashes (`—`, `–`) for connective, parenthetical, or
+  dramatic punctuation. Recast with a comma, period, colon, semicolon, or
+  parentheses. If a sentence seems to need a dash, it usually wants to be two
+  sentences.
 
 As a practical edit, mark every adjective and adverb in a paragraph that feels
 ornamental. Keep the one concrete modifier that helps the child picture the
 moment; remove the rest.
+
+Em and en dashes are banned in story prose because they read as a machine-writing
+tell and flatten read-aloud cadence. The straight hyphen in compound words
+(`true-hearted`, `read-aloud`) is fine. Before any story is published, the prose
+must contain zero `—` and `–` glyphs in the title, summary, body, and
+`virtueDescription`. A quick check is `grep -nP "—|–"` over the rendered fields.
 
 ## SEO Boundary
 
@@ -166,6 +179,7 @@ The review note must name the two exemplars used and record:
 - whether sentence rhythm stays read-aloud plain;
 - whether the ending trusts an image or action instead of explaining the symbol;
 - whether `content` contains narrative only;
+- whether the prose is free of em and en dashes (`—`, `–`);
 - whether the canonical virtue and any sub-virtue angle are mapped cleanly.
 
 Use `content/vault/drift-diagnosis.md` as the current list of known failure
@@ -181,6 +195,7 @@ Before a story is published, Margaret should confirm:
 - the title is anthology-clean;
 - the story body contains no SEO scaffolding or related-reading block;
 - the moral/reflection appears once, through `virtueDescription`;
+- the prose uses no em or en dashes (`—`, `–`) as connective punctuation;
 - the story maps to the seven-virtue canon;
 - source/provenance is accurate or uncertainty is cut;
 - image alt text is meaningful;


### PR DESCRIPTION
## Why

The board flagged that em dashes are still throughout the published stories and asked whether our standards enforce against them. They did not. `writing.md` had a "Sentence Rhythm And Diction" section but **no punctuation rule**, and the three locked vault exemplars each modeled an em dash — so every drafter reproduced the pattern faithfully.

## What changed

- **`writing.md`** — explicit no-em/en-dash rule in four enforcement points: the drift ban list, the sentence-rhythm rule, the vault comparison gate, and the approval checklist. Straight hyphens in compounds (`true-hearted`) remain fine.
- **`AGENTS.md`** — editorial guardrail line so the rule is visible at the top-level agent contract, with a `grep -nP "—|–"` pre-publish check.
- **`content/vault/drift-diagnosis.md`** — new failure pattern (#9) + A2 input so the gate documents it.
- **Locked exemplars** — removed the single em dash in each of `androcles-and-the-lion`, `david-and-mephibosheth`, `the-cherry-tree` so the comparison gate stops teaching the pattern. (`androcles` summary also carries promotional drift — flagged to Margaret for a separate editorial pass, out of scope here.)

## Not in this PR

Live Basehub story prose (`the-boy-and-the-filberts` has 5 em dashes in the CMS body; `the-ant-and-the-grasshopper` is already clean) — that is a CMS edit owned by editorial, tracked as a child issue of PRO-73.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
