### PR TITLE
PRO-86: durable post-publish revalidation for Basehub content

### DIFF
--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { revalidatePath, revalidateTag } from 'next/cache'
+import { timingSafeEqual } from 'crypto'
+import { BASEHUB_CACHE_TAG } from '@/lib/basehub'
+
+// On-demand revalidation endpoint (PRO-86).
+//
+// Margaret's publish pipeline calls this right after a successful Basehub commit
+// to refresh production instantly, without an engineer rebuild and without the
+// Svix-signed dependency of `/revalidate-sitemap`. It is authenticated with the
+// EXISTING `BASEHUB_WEBHOOK_SECRET` (a shared bearer token) so no new env var /
+// governance action is required. Even if it is never called, content still
+// refreshes within minutes via the time-based ISR window in `src/lib/basehub.ts`.
+export const dynamic = 'force-dynamic'
+
+/** Constant-time comparison that tolerates length mismatches. */
+function tokenMatches(provided: string, expected: string): boolean {
+  const a = Buffer.from(provided)
+  const b = Buffer.from(expected)
+  if (a.length !== b.length) return false
+  return timingSafeEqual(a, b)
+}
+
+/** Accept the secret as `Authorization: Bearer <secret>` or `x-revalidate-token`. */
+function extractToken(req: NextRequest): string | null {
+  const auth = req.headers.get('authorization')
+  if (auth?.startsWith('Bearer ')) return auth.slice('Bearer '.length).trim()
+  const header = req.headers.get('x-revalidate-token')
+  return header?.trim() || null
+}
+
+function revalidateAll() {
+  // Bust the Basehub data cache so the next render fetches fresh content...
+  // ('max' is the Next 16 immediate-purge profile for route handlers.)
+  revalidateTag(BASEHUB_CACHE_TAG, 'max')
+  // ...and refresh the static route shells that list/render that content.
+  revalidatePath('/')
+  revalidatePath('/stories')
+  revalidatePath('/stories/[slug]', 'page')
+  revalidatePath('/sitemap.xml')
+}
+
+export async function POST(req: NextRequest) {
+  const secret = process.env.BASEHUB_WEBHOOK_SECRET
+  if (!secret) {
+    return NextResponse.json(
+      { error: 'Revalidation not configured (BASEHUB_WEBHOOK_SECRET unset)' },
+      { status: 500 },
+    )
+  }
+
+  const token = extractToken(req)
+  if (!token || !tokenMatches(token, secret)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  revalidateAll()
+
+  return NextResponse.json({
+    revalidated: true,
+    tag: BASEHUB_CACHE_TAG,
+    paths: ['/', '/stories', '/stories/[slug]', '/sitemap.xml'],
+  })
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,9 @@ export const metadata: Metadata = {
   },
 }
 
+// ISR: pick up newly published stories within minutes, no rebuild (PRO-86).
+export const revalidate = 300
+
 export default async function Home() {
   const stories = await getAllStories();
   const [lead, ...rest] = stories;

--- a/src/app/revalidate-sitemap/route.ts
+++ b/src/app/revalidate-sitemap/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { revalidatePath } from 'next/cache'
+import { revalidatePath, revalidateTag } from 'next/cache'
 import { createHmac } from 'crypto'
+import { BASEHUB_CACHE_TAG } from '@/lib/basehub'
 
 // Force dynamic for webhook endpoint
 export const dynamic = 'force-dynamic'
@@ -36,6 +37,8 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Request too old' }, { status: 401 })
   }
 
+  // Bust the Basehub data cache first so re-rendered pages fetch fresh content.
+  revalidateTag(BASEHUB_CACHE_TAG, 'max')
   revalidatePath('/sitemap.xml')
   revalidatePath('/')
   revalidatePath('/stories')

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -4,6 +4,9 @@ import { getVirtueSlugs } from '@/lib/virtues'
 
 const BASE_URL = 'https://classicalvirtues.com'
 
+// ISR: keep the sitemap fresh with newly published stories, no rebuild (PRO-86).
+export const revalidate = 300
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const stories = await getAllStories()
 

--- a/src/app/stories/[slug]/page.tsx
+++ b/src/app/stories/[slug]/page.tsx
@@ -16,6 +16,11 @@ import type { ReactNode } from 'react'
 
 type Params = Promise<{ slug: string }>
 
+// ISR: refresh story pages at most every 5 minutes so Basehub publishes land in
+// production without an engineer rebuild (PRO-86). Must be a literal for Next's
+// static analysis; mirrors STORY_REVALIDATE_SECONDS in src/lib/basehub.ts.
+export const revalidate = 300
+
 export async function generateStaticParams() {
   const stories = await getAllStories();
   return stories.map((story) => ({

--- a/src/app/stories/page.tsx
+++ b/src/app/stories/page.tsx
@@ -11,6 +11,9 @@ export const metadata: Metadata = {
   },
 }
 
+// ISR: pick up newly published stories within minutes, no rebuild (PRO-86).
+export const revalidate = 300
+
 export default async function StoriesIndex() {
   const stories = await getAllStories()
 

--- a/src/lib/basehub.ts
+++ b/src/lib/basehub.ts
@@ -2,6 +2,34 @@ import { basehub } from 'basehub'
 import type { StoriesItem } from '../../basehub-types'
 import '../../basehub.config' // Import the config to ensure it's loaded
 
+/**
+ * Stable Next.js cache tag applied to every Basehub story query.
+ *
+ * In production the Basehub SDK tags each query with a per-query content hash
+ * and NO time-based revalidate, so the data cache lives until that opaque hash
+ * is invalidated. We override `next` with a single stable tag plus a revalidate
+ * window so content can be refreshed two ways (see PRO-86):
+ *   1. Time-based ISR — production re-fetches at most every
+ *      `STORY_REVALIDATE_SECONDS`, so a publish lands with zero engineer action.
+ *   2. On-demand — `POST /api/revalidate` calls `revalidateTag(BASEHUB_CACHE_TAG)`
+ *      for an instant refresh straight from the publish pipeline.
+ */
+export const BASEHUB_CACHE_TAG = 'basehub:stories'
+
+/**
+ * ISR window (seconds) for Basehub-backed content. Five minutes keeps the
+ * "refresh within minutes, no rebuild" guarantee while keeping regeneration
+ * cost negligible for an infrequently-published anthology.
+ */
+export const STORY_REVALIDATE_SECONDS = 300
+
+// Shared Next.js fetch cache options for Basehub queries. Replacing the SDK's
+// default per-query hash tag with a stable tag is intentional: it gives us a
+// known handle for on-demand `revalidateTag` while preserving time-based ISR.
+const STORY_FETCH_OPTIONS = {
+  next: { revalidate: STORY_REVALIDATE_SECONDS, tags: [BASEHUB_CACHE_TAG] },
+}
+
 // Use BaseHub's generated types for full type safety.
 export type Story = StoriesItem
 
@@ -28,7 +56,7 @@ const STORY_ITEM_FIELDS = {
 // Fetch all stories with proper BaseHub caching.
 export async function getAllStories(): Promise<Story[]> {
   try {
-    const data = await basehub().query({ stories: { items: STORY_ITEM_FIELDS } })
+    const data = await basehub(STORY_FETCH_OPTIONS).query({ stories: { items: STORY_ITEM_FIELDS } })
     return data.stories.items as Story[]
   } catch (error) {
     console.error('Error fetching stories from Basehub:', error)
@@ -39,7 +67,7 @@ export async function getAllStories(): Promise<Story[]> {
 // Fetch a single story by slug with proper BaseHub caching.
 export async function getStoryBySlug(slug: string): Promise<Story | null> {
   try {
-    const data = await basehub().query({ stories: { __args: { first: 100 }, items: STORY_ITEM_FIELDS } })
+    const data = await basehub(STORY_FETCH_OPTIONS).query({ stories: { __args: { first: 100 }, items: STORY_ITEM_FIELDS } })
 
     // Find the story with matching slug
     const story = data.stories.items.find((item: Pick<Story, '_slug'>) => item._slug === slug)


### PR DESCRIPTION
## Summary

Production `www.classicalvirtues.com` kept serving stale static HTML after a Basehub publish: story pages were SSG with no ISR, and the Basehub SDK tags each query with **no** time-based revalidate, so data lived in cache until the opaque per-query hash was purged. The existing `/revalidate-sitemap` webhook never fires on Margaret's Mutation-API commits (it requires Svix-signed headers).

This adds two complementary, **governance-safe** mechanisms (no new env var):

### 1. Time-based ISR (primary, zero coordination)
- `src/lib/basehub.ts` applies a stable cache tag `basehub:stories` and a `300s` revalidate to every story query.
- `/`, `/stories`, `/stories/[slug]`, and `sitemap.xml` export `revalidate = 300`.
- Result: a publish refreshes production within ~5 minutes with **zero engineer action**, even if nothing else is wired.

### 2. On-demand refresh (instant, optional pipeline hook)
- New `POST /api/revalidate`, authenticated with the **existing** `BASEHUB_WEBHOOK_SECRET` (bearer token, no Svix, no new env var).
- Calls `revalidateTag('basehub:stories','max')` + `revalidatePath` for `/`, `/stories`, `/stories/[slug]` (page), `/sitemap.xml`.
- Margaret's publish script can call it right after a successful commit for instant refresh.
- `/revalidate-sitemap` now also busts the data-cache tag, so the Basehub dashboard-webhook option works too.

## Verification
- `pnpm run lint` ✅
- `npx tsc --noEmit` ✅
- `npx next build` ✅ — route table shows `/`, `/stories`, `/sitemap.xml` at **Revalidate 5m** and `/api/revalidate` wired as a dynamic route.

## Remaining (post-merge)
End-to-end on a **real publish** requires this to be deployed to prod, then observed on Margaret's next publish (auto-refresh within ~5 min via ISR, or instant if the pipeline calls `/api/revalidate`).

Closes PRO-86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)