### PR TITLE
PRO-99: Lighthouse CI on 3 story pages (enforce >=90 SEO/perf)

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,70 @@
+name: Lighthouse CI
+
+# Enforce SEO & performance budgets on representative story pages (PRO-99,
+# follow-up from the PRO-94 audit). The static SEO/perf posture is strong; this
+# job produces the first *numeric* Lighthouse run and keeps it from regressing.
+#
+# It runs against the per-PR Vercel preview deployment (Vercel's GitHub
+# integration is connected, so every PR gets a preview), waits for that preview
+# to finish, then audits three anthology story pages and fails the check if
+# performance or SEO drops below 90.
+
+on:
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+    inputs:
+      preview_url:
+        description: "Base URL to audit (e.g. https://classical-virtues-xxxx.vercel.app). Used only for manual runs."
+        required: false
+
+# One Lighthouse run per PR head; cancel superseded runs.
+concurrency:
+  group: lighthouse-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lighthouse:
+    name: Lighthouse (story pages, >=90 SEO/perf)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Wait for the Vercel preview deployment
+        id: preview
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: patrickedqvist/wait-for-vercel-preview@v1.3.2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # Give Vercel time to build + deploy the preview before auditing.
+          max_timeout: 600
+          check_interval: 10
+
+      - name: Resolve base URL to audit
+        id: base
+        run: |
+          URL="${{ steps.preview.outputs.url }}"
+          if [ -z "$URL" ]; then
+            URL="${{ github.event.inputs.preview_url }}"
+          fi
+          # Strip any trailing slash so page paths concatenate cleanly.
+          URL="${URL%/}"
+          if [ -z "$URL" ]; then
+            echo "::error::No preview URL was resolved. On PRs this means the Vercel preview deployment never reported success; for manual runs pass the preview_url input."
+            exit 1
+          fi
+          echo "Auditing base URL: $URL"
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+
+      - name: Run Lighthouse CI
+        uses: treosh/lighthouse-ci-action@v12
+        with:
+          # Three representative, stable anthology story pages.
+          urls: |
+            ${{ steps.base.outputs.url }}/stories/the-ant-and-the-grasshopper
+            ${{ steps.base.outputs.url }}/stories/androcles-and-the-lion
+            ${{ steps.base.outputs.url }}/stories/the-boy-and-the-filberts
+          configPath: ./.lighthouserc.json
+          uploadArtifacts: true
+          temporaryPublicStorage: true

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -2,12 +2,19 @@ name: Lighthouse CI
 
 # Enforce SEO & performance budgets on representative story pages (PRO-99,
 # follow-up from the PRO-94 audit). The static SEO/perf posture is strong; this
-# job produces the first *numeric* Lighthouse run and keeps it from regressing.
+# job produces numeric Lighthouse runs and keeps SEO/perf from regressing.
 #
-# It runs against the per-PR Vercel preview deployment (Vercel's GitHub
-# integration is connected, so every PR gets a "Preview" GitHub Deployment),
-# waits for that preview to finish, then audits three anthology story pages and
-# fails the check if performance or SEO drops below 90.
+# On a PR it audits the per-PR Vercel *preview* deployment (Vercel's GitHub
+# integration is connected, so every PR gets a "Preview" GitHub Deployment).
+# Preview deployments are protected by Vercel Deployment Protection, so an
+# anonymous audit would hit the login wall. To audit the real pages, set the
+# VERCEL_AUTOMATION_BYPASS_SECRET repo secret (Vercel → Project Settings →
+# Deployment Protection → Protection Bypass for Automation); the job then sends
+# it as the `x-vercel-protection-bypass` header. Without it, the job warns and
+# the audit will (expectedly) fail against the login page.
+#
+# It can also be run manually (workflow_dispatch) against any public base URL —
+# e.g. the production site — via the `preview_url` input.
 
 on:
   pull_request:
@@ -15,7 +22,7 @@ on:
   workflow_dispatch:
     inputs:
       preview_url:
-        description: "Base URL to audit (e.g. https://classical-virtues-xxxx.vercel.app). Used only for manual runs."
+        description: "Base URL to audit (e.g. https://classicalvirtues.com). Manual runs only."
         required: false
 
 # One Lighthouse run per PR head; cancel superseded runs.
@@ -27,11 +34,13 @@ jobs:
   lighthouse:
     name: Lighthouse (story pages, >=90 SEO/perf)
     runs-on: ubuntu-latest
+    env:
+      VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Resolve Vercel preview URL
+      - name: Resolve base URL to audit
         id: base
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -40,12 +49,13 @@ jobs:
           # pull_request event is the synthetic merge commit that has no preview.
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           MANUAL_URL: ${{ github.event.inputs.preview_url }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
 
           resolve_url=""
 
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
+          if [ "$EVENT_NAME" = "pull_request" ]; then
             echo "Waiting for a successful Vercel Preview deployment for $HEAD_SHA ..."
             # Poll the GitHub Deployments API (populated by vercel[bot]) for up to
             # ~10 minutes. gh + GITHUB_TOKEN only; no extra secrets required.
@@ -76,12 +86,28 @@ jobs:
           resolve_url="${resolve_url%/}"
 
           if [ -z "$resolve_url" ]; then
-            echo "::error::No preview URL resolved. On PRs this means no successful Vercel Preview deployment appeared for $HEAD_SHA within the timeout; for manual runs pass the preview_url input."
+            echo "::error::No base URL resolved. On PRs this means no successful Vercel Preview deployment appeared for $HEAD_SHA within the timeout; for manual runs pass the preview_url input."
             exit 1
           fi
 
           echo "Auditing base URL: $resolve_url"
           echo "url=$resolve_url" >> "$GITHUB_OUTPUT"
+
+      - name: Build effective Lighthouse config
+        # Injects the Vercel protection-bypass header when the secret is present,
+        # so protected preview deployments are audited as the real pages instead
+        # of the Vercel login wall. Secret value is never printed.
+        run: |
+          set -euo pipefail
+          if [ -n "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]; then
+            echo "Protection-bypass secret detected — auditing with x-vercel-protection-bypass header."
+            jq --arg s "$VERCEL_AUTOMATION_BYPASS_SECRET" \
+              '.ci.collect = (.ci.collect // {}) | .ci.collect.settings = ((.ci.collect.settings // {}) + {extraHeaders: {"x-vercel-protection-bypass": $s}})' \
+              .lighthouserc.json > .lighthouserc.effective.json
+          else
+            echo "::warning::VERCEL_AUTOMATION_BYPASS_SECRET is not set. Protected Vercel preview deployments will redirect to the login wall and the audit will fail. Add it under Settings → Secrets → Actions to enforce >=90 on previews."
+            cp .lighthouserc.json .lighthouserc.effective.json
+          fi
 
       - name: Run Lighthouse CI
         uses: treosh/lighthouse-ci-action@v12
@@ -91,6 +117,6 @@ jobs:
             ${{ steps.base.outputs.url }}/stories/the-ant-and-the-grasshopper
             ${{ steps.base.outputs.url }}/stories/androcles-and-the-lion
             ${{ steps.base.outputs.url }}/stories/the-boy-and-the-filberts
-          configPath: ./.lighthouserc.json
+          configPath: ./.lighthouserc.effective.json
           uploadArtifacts: true
           temporaryPublicStorage: true

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -118,5 +118,8 @@ jobs:
             ${{ steps.base.outputs.url }}/stories/androcles-and-the-lion
             ${{ steps.base.outputs.url }}/stories/the-boy-and-the-filberts
           configPath: ./.lighthouserc.effective.json
+          # Median of 3 runs per URL for a stable gate (the action's own knob
+          # takes precedence over collect.numberOfRuns in the config).
+          runs: 3
           uploadArtifacts: true
           temporaryPublicStorage: true

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -5,9 +5,9 @@ name: Lighthouse CI
 # job produces the first *numeric* Lighthouse run and keeps it from regressing.
 #
 # It runs against the per-PR Vercel preview deployment (Vercel's GitHub
-# integration is connected, so every PR gets a preview), waits for that preview
-# to finish, then audits three anthology story pages and fails the check if
-# performance or SEO drops below 90.
+# integration is connected, so every PR gets a "Preview" GitHub Deployment),
+# waits for that preview to finish, then audits three anthology story pages and
+# fails the check if performance or SEO drops below 90.
 
 on:
   pull_request:
@@ -31,31 +31,57 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Wait for the Vercel preview deployment
-        id: preview
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: patrickedqvist/wait-for-vercel-preview@v1.3.2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          # Give Vercel time to build + deploy the preview before auditing.
-          max_timeout: 600
-          check_interval: 10
-
-      - name: Resolve base URL to audit
+      - name: Resolve Vercel preview URL
         id: base
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          # PR head SHA is what Vercel deploys — NOT github.sha, which on a
+          # pull_request event is the synthetic merge commit that has no preview.
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          MANUAL_URL: ${{ github.event.inputs.preview_url }}
         run: |
-          URL="${{ steps.preview.outputs.url }}"
-          if [ -z "$URL" ]; then
-            URL="${{ github.event.inputs.preview_url }}"
+          set -euo pipefail
+
+          resolve_url=""
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "Waiting for a successful Vercel Preview deployment for $HEAD_SHA ..."
+            # Poll the GitHub Deployments API (populated by vercel[bot]) for up to
+            # ~10 minutes. gh + GITHUB_TOKEN only; no extra secrets required.
+            for i in $(seq 1 60); do
+              dep_id="$(gh api "repos/$REPO/deployments?sha=$HEAD_SHA&environment=Preview" --jq '.[0].id // empty' 2>/dev/null || true)"
+              if [ -n "$dep_id" ]; then
+                state="$(gh api "repos/$REPO/deployments/$dep_id/statuses" --jq '.[0].state // empty' 2>/dev/null || true)"
+                target="$(gh api "repos/$REPO/deployments/$dep_id/statuses" --jq '.[0].environment_url // .[0].target_url // empty' 2>/dev/null || true)"
+                echo "  attempt $i: deployment $dep_id state=${state:-none}"
+                if [ "$state" = "success" ] && [ -n "$target" ]; then
+                  resolve_url="$target"
+                  break
+                fi
+                if [ "$state" = "failure" ] || [ "$state" = "error" ]; then
+                  echo "::error::Vercel Preview deployment $dep_id reported state=$state"
+                  exit 1
+                fi
+              else
+                echo "  attempt $i: no Preview deployment for $HEAD_SHA yet"
+              fi
+              sleep 10
+            done
+          else
+            resolve_url="$MANUAL_URL"
           fi
+
           # Strip any trailing slash so page paths concatenate cleanly.
-          URL="${URL%/}"
-          if [ -z "$URL" ]; then
-            echo "::error::No preview URL was resolved. On PRs this means the Vercel preview deployment never reported success; for manual runs pass the preview_url input."
+          resolve_url="${resolve_url%/}"
+
+          if [ -z "$resolve_url" ]; then
+            echo "::error::No preview URL resolved. On PRs this means no successful Vercel Preview deployment appeared for $HEAD_SHA within the timeout; for manual runs pass the preview_url input."
             exit 1
           fi
-          echo "Auditing base URL: $URL"
-          echo "url=$URL" >> "$GITHUB_OUTPUT"
+
+          echo "Auditing base URL: $resolve_url"
+          echo "url=$resolve_url" >> "$GITHUB_OUTPUT"
 
       - name: Run Lighthouse CI
         uses: treosh/lighthouse-ci-action@v12

--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -1,0 +1,15 @@
+{
+  "ci": {
+    "collect": {
+      "numberOfRuns": 3
+    },
+    "assert": {
+      "assertions": {
+        "categories:performance": ["error", { "minScore": 0.9 }],
+        "categories:seo": ["error", { "minScore": 0.9 }],
+        "categories:accessibility": ["warn", { "minScore": 0.9 }],
+        "categories:best-practices": ["warn", { "minScore": 0.9 }]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Follow-up from the PRO-94 codebase-health audit (parent PRO-94). The audit sandbox had no headless Chrome, so numeric Lighthouse scores were never produced. This wires a real, enforcing Lighthouse check into CI, produces the **first numeric run**, and guards against SEO/perf regressions.

## What this adds
- **`.github/workflows/lighthouse.yml`** — a `pull_request` (→ `main`) job (also `workflow_dispatch`) that:
  1. Resolves the per-PR **Vercel preview** URL from the GitHub Deployment on the **PR head SHA** (not `github.sha`, which is the synthetic merge commit with no preview).
  2. Injects the Vercel **protection-bypass** header when `VERCEL_AUTOMATION_BYPASS_SECRET` is set (preview deployments are protection-gated; without it the audit hits the Vercel login wall — the job warns loudly).
  3. Runs `treosh/lighthouse-ci-action@v12` (median of 3 runs) against **3 story pages**: `the-ant-and-the-grasshopper`, `androcles-and-the-lion`, `the-boy-and-the-filberts`.
  4. Uploads reports (temporary public storage + artifacts).
- **`.lighthouserc.json`** — assertions: `performance >= 0.9` **error**, `seo >= 0.9` **error**; accessibility / best-practices `>= 0.9` **warn**.

## First numeric run (recorded ✅)
`workflow_dispatch` against public production (`https://classicalvirtues.com`), single mobile audit per page:

| Page | SEO | Performance |
|---|---|---|
| the-ant-and-the-grasshopper | ✅ ≥90 | ❌ **0.85** |
| androcles-and-the-lion | ✅ ≥90 | ❌ **0.85** |
| the-boy-and-the-filberts | ✅ ≥90 | (pass/near — not annotated) |

**SEO posture is confirmed strong (≥90).** **Performance is ~0.85 — below the 90 target the audit assumed was "highly likely."** Remediation tracked in **PRO-102**.

## Two things needed before this can merge green
1. **Preview auditing (PRO-103, CEO):** add `VERCEL_AUTOMATION_BYPASS_SECRET` so PR runs audit the real preview pages instead of the Vercel login wall.
2. **Perf gate policy:** either land PRO-102 (get story pages to ≥90) so the gate is green, or temporarily set `performance` to `warn` while SEO stays enforced at ≥90.

No editorial, rendering, or Basehub content changes — CI/infrastructure only.

Relates to PRO-99 · Blocked-by PRO-103 · Follow-up PRO-102